### PR TITLE
Api error handling

### DIFF
--- a/src/Compensation.jsx
+++ b/src/Compensation.jsx
@@ -201,6 +201,8 @@ class Compensation extends Component {
           datosSogamoso: res,
         });
       });
+    // TODO: When the promise is rejected, we need to show a "Data not available" error
+    // (in the SZH selector). But the application won't break as it currently is
   }
 
   render() {

--- a/src/Compensation.jsx
+++ b/src/Compensation.jsx
@@ -65,7 +65,13 @@ class Compensation extends Component {
           },
         }
       ));
-    });
+    })
+      .catch(() => (
+        this.setState({
+          activeLayers: {},
+          layers: {},
+        })
+      ));
   }
 
   featureStyle = (feature) => {

--- a/src/Search.jsx
+++ b/src/Search.jsx
@@ -151,6 +151,8 @@ class Search extends Component {
           basinData: res,
         }));
       });
+    // TODO: When the promise is rejected, we need to show a "Data not available" error
+    // (in the table). But the application won't break as it currently is
   }
 
   /** ****************************** */

--- a/src/compensation/Drawer.jsx
+++ b/src/compensation/Drawer.jsx
@@ -97,6 +97,8 @@ class Drawer extends React.Component {
           totals,
         });
       });
+    // TODO: When the promise is rejected, we need to show a "Data not available" error
+    // (in the table). But the application won't break as it currently is
   }
 
   /**

--- a/src/search/Drawer.jsx
+++ b/src/search/Drawer.jsx
@@ -42,6 +42,15 @@ class Drawer extends React.Component {
             biomas: res,
           },
         }));
+      })
+      .catch(() => {
+        this.setState(prevState => ({
+          ...prevState,
+          data: {
+            ...prevState.data,
+            biomas: false,
+          },
+        }));
       });
     ElasticAPI.requestCarByFCArea('CORPOBOYACA')
       .then((res) => {
@@ -50,6 +59,15 @@ class Drawer extends React.Component {
           data: {
             ...prevState.data,
             fc: res,
+          },
+        }));
+      })
+      .catch(() => {
+        this.setState(prevState => ({
+          ...prevState,
+          data: {
+            ...prevState.data,
+            fc: false,
           },
         }));
       });
@@ -62,15 +80,38 @@ class Drawer extends React.Component {
             distritos: res,
           },
         }));
+      })
+      .catch(() => {
+        this.setState(prevState => ({
+          ...prevState,
+          data: {
+            ...prevState.data,
+            distritos: false,
+          },
+        }));
       });
   }
 
+  /**
+   * Function to render a graph
+   *
+   * @param {any} data Graph data, it can be null (data hasn't loaded), false (data not available)
+   *  or an Object with the data.
+   * @param {string} labelX axis X label
+   * @param {string} labelY axis Y label
+   * @param {string} graph graph type
+   * @param {string} graphTitle graph title
+   */
   renderGraph = (data, labelX, labelY, graph, graphTitle) => {
     // While data is being retrieved from server
-    if (!data) {
+    let errorMessage = null;
+    if (data === null) errorMessage = 'Loading data...';
+    else if (!data) errorMessage = `Data for ${graphTitle} not available`;
+    if (errorMessage) {
+      // TODO: ask Cesar to make this message nicer
       return (
-        <div>
-          Loading data...
+        <div className="errorData">
+          {errorMessage}
         </div>
       );
     }


### PR DESCRIPTION
* Some rejections aren't causing the application to break, in those cases I added a comment because making the error visible to users implies design and flow issues (maybe show a popup or a message in some part of the drawer?)