### PR TITLE
Hotfix: Fija el estado de las fichas del carrusel y soluciona inconsistencias de estilos en el Home

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biotablero",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "packageManager": "pnpm@8.15.1",
   "scripts": {
     "start": "PORT=5000 serve -s build",

--- a/src/main.css
+++ b/src/main.css
@@ -1,4 +1,6 @@
+@import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap');
 * {
+    font-family: "Lato", system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif !important;
     margin: 0;
     padding: 0;
 }

--- a/src/main.css
+++ b/src/main.css
@@ -13,7 +13,6 @@ html {
 }
 body {
     font-size: 12px;
-    font-family: "Roboto", sans-serif;
     height: 100%;
 }
 iframe#webpack-dev-server-client-overlay {
@@ -38,12 +37,6 @@ header {
 }
 footer {
     grid-area: footer;
-}
-h1,
-h2,
-h3,
-h4 {
-    font-family: "Lato", sans-serif;
 }
 .clearfix:before,
 .clearfix:after {
@@ -93,7 +86,6 @@ a,
 .cabezoteRight h2 {
     display: inline-block;
     font-size: 2em;
-    font-family: "Lato", sans-serif;
     color: #000000;
     transform: translateY(32%);
     -webkit-transform: translateY(32%);
@@ -181,7 +173,6 @@ h2 {
     font-size: 22px;
     font-weight: 300;
     margin-bottom: 10px;
-    font-family: "Roboto", sans-serif;
     text-align: center;
 }
 .finder {
@@ -195,7 +186,6 @@ h2 {
     text-transform: uppercase;
     color: transparent;
     font-weight: 300;
-    font-family: "Lato", sans-serif;
     border: 2px solid transparent;
     transition: all 1s ease;
 }
@@ -320,7 +310,6 @@ menu button.active {
 .hidden-true p {
     max-width: 87%;
     margin: auto;
-    font-family: "Lato", sans-serif;
     font-size: 14px;
 }
 .rotate-false {
@@ -947,7 +936,6 @@ a#reset-filters {
     transition: all 1s ease;
 }
 .selector {
-    font-family: "Roboto", sans-serif;
     font-size: 12px;
 }
 .selector h1 {
@@ -1113,7 +1101,6 @@ a#reset-filters {
     flex: 3 1 60%;
     -webkit-order: 1;
     order: 1;
-    font-family: "Roboto", sans-serif !important;
     z-index: 0;
 }
 .leaflet-control-zoom a {
@@ -1465,7 +1452,6 @@ div[class*="eaRHYv"] {
 }
 .graphinfo2-true p,
 .graphinfo3-true p {
-    font-family: "Lato", sans-serif;
     color: #424242;
     padding: 3px 8px 10px 0;
     text-align: left;
@@ -2426,7 +2412,6 @@ h3.warningNote {
     justify-content: space-between;
     align-items: center;
     padding: 2rem;
-    font-family: "Lato", sans-serif;
 }
 .colPort2 {
     width: 65vw;

--- a/src/newStyles.css
+++ b/src/newStyles.css
@@ -89,11 +89,11 @@ body {
 
 img.Modulos {
     background-color: rgba(17, 17, 17, 0.52);
-    /* border-bottom: 1px solid #ffffff; */
-    border-bottom: 1px solid var(--blanco);
+    outline: 2px solid var(--blanco);
+	outline-offset: 1px;
     backdrop-filter: blur(2px);
     padding: 23% 17%;
-    border-radius: 6px;
+    border-radius: 11px 11px 0 11px;
     overflow: auto;
     margin: auto;
 }

--- a/src/newStyles.css
+++ b/src/newStyles.css
@@ -1,8 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap');
-
-* {
-    font-family: "Lato", system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif !important;
-}
 body {
     margin: 0;
 }

--- a/src/newStyles.css
+++ b/src/newStyles.css
@@ -1,5 +1,7 @@
+@import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap');
+
 * {
-    font-family: "Lato", sans-serif;
+    font-family: "Lato", system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif !important;
 }
 body {
     margin: 0;
@@ -124,10 +126,6 @@ img.Modulos {
 #Tabs .css-1ehaqqx-MuiButtonBase-root-MuiTabScrollButton-root {
     display: none;
 }
-#Tabs h1,
-#Tabs p {
-    font-family: "Lato";
-}
 #Tabs p a {
     font-weight: 600;
     color: var(--rojo);
@@ -142,7 +140,6 @@ img.Modulos {
 #Tabs {
     position: relative;
     background-color: var(--gris);
-    font-family: "Lato";
     padding-top: 20px;
     padding-bottom: 59px;
 }

--- a/src/pages/home/Carrousel.jsx
+++ b/src/pages/home/Carrousel.jsx
@@ -59,7 +59,7 @@ function Carrousel({ setActiveTab, setShowQueEs }) {
         { id: 2, title: "Indicadores de Biodiversidad", image: Indicadores, link: "/Indicadores", auth: false },
         { id: 3, title: "Portafolios", image: Portafolio, link: "/Portafolios", auth: false },
         //{ id: 4, title: "Monitoreo Comunitario", image: Comunitario, link: "/Monitoreo", auth: false },
-        { id: 5, title: "Compensación Ambiental", image: compensacionAmbiental, link: "/GEB/Compensaciones", auth: true },
+        { id: 4, title: "Compensación Ambiental", image: compensacionAmbiental, link: "/GEB/Compensaciones", auth: true },
     ];
 
     const availableModules = user ? modules : modules.filter((module) => !module.auth);

--- a/src/pages/home/Carrousel.jsx
+++ b/src/pages/home/Carrousel.jsx
@@ -7,7 +7,6 @@ import { Grid, Container, Button } from "@mui/material";
 import KeyboardArrowLeft from "@mui/icons-material/KeyboardArrowLeft";
 import KeyboardArrowRight from "@mui/icons-material/KeyboardArrowRight";
 import iconoinfo from "images/icono-info.svg";
-import iconomas from "images/icono-mas.svg";
 import Consultasgeograficas from "images/consulta-geografica-logo.svg";
 import Indicadores from "images/indicadores-biodiversidad-icono.svg";
 import Portafolio from "images/portafolio-icono.svg";
@@ -37,7 +36,6 @@ function NextArrow(props) {
 function Carrousel({ setActiveTab, setShowQueEs }) {
     const { user } = useContext(AppContext);
     const [activeModule, setActiveModule] = useState(null);
-    const [showContainer, setShowContainer] = useState(false);
 
     const settings = {
         dots: true,
@@ -66,26 +64,19 @@ function Carrousel({ setActiveTab, setShowQueEs }) {
 
     const availableModules = user ? modules : modules.filter((module) => !module.auth);
 
-    const [animateContainer, setAnimateContainer] = useState(false);
 
     const handleClick = (id) => {
         if (activeModule === id) {
-            setAnimateContainer(false);
-            setTimeout(() => {
-                setShowContainer(false);
-                setActiveModule(null);
-                setActiveTab(0);
-                setShowQueEs(true);
-            }, 300);
+			setActiveModule(null);
+			setActiveTab(0);
+			setShowQueEs(true);
         } else {
             setActiveModule(id);
-            setShowContainer(true);
             setActiveTab(id);
             setShowQueEs(false);
-
-            setTimeout(() => setAnimateContainer(true), 300);
         }
     };
+
 
     return (
         <div id="CarrouselBio" className="slider-container imagen-fondo">
@@ -96,42 +87,36 @@ function Carrousel({ setActiveTab, setShowQueEs }) {
                 <Slider {...settings}>
                     {availableModules.map((module) => (
                         <div key={module.id} className="ModuloPrincipal" style={{ height: "auto", padding: 12 }}>
-                            <div className={`moduactivo ${activeModule === module.id ? "active" : ""}`}>
-                                <Tooltip title="Haz clic para explorar" arrow>
-                                    <img className="Modulos" src={module.image} alt={module.title} style={{ width: "65%", height: "auto", cursor: "pointer" }} onClick={() => handleClick(module.id)} />
-                                </Tooltip>
+                            <div className="moduactivo active" >
+								<Link to={module.link}>
+									<Tooltip title="Haz clic para explorar" arrow>
+										<img className="Modulos" src={module.image} alt={module.title} style={{ width: "65%", height: "auto", cursor: "pointer" }} />
+									</Tooltip>
 
-                                {showContainer && activeModule === module.id && (
-                                    <Grid container spacing={2} alignItems="center" className={`contenedor ${animateContainer ? "activo" : ""}`} gap={1}>
-                                        <Grid item xs={12} sm={7} md={6} lg={7} sx={{ textAlign: { xs: "center", sm: "left" } }}>
-                                            <span>{module.title}</span>
-                                        </Grid>
-                                        <Grid className="btncricle" item xs={3} sm={2} md={2} lg={2}>
-                                            <Tooltip title="Más información" arrow>
-                                                <Button
-                                                    onClick={() => handleClick(module.id)}
-                                                    style={{
-                                                        backgroundColor: "#e84a5f",
-                                                        border: "2px solid #fff",
-                                                        padding: "12px",
-                                                    }}
-                                                >
-                                                    <img src={iconoinfo} alt="Información" />
-                                                </Button>
-                                            </Tooltip>
-                                        </Grid>
-
-                                        <Grid className="btncricle" item xs={3} sm={2} md={2} lg={2}>
-                                            <Tooltip title="Ir al módulo" arrow>
-                                                <Link to={module.link} style={{ textDecoration: "none" }}>
-                                                    <Button>
-                                                        <img src={iconomas} alt="Ir al módulo" />
-                                                    </Button>
-                                                </Link>
-                                            </Tooltip>
-                                        </Grid>
-                                    </Grid>
-                                )}
+									<Grid container alignItems="center" className="contenedor activo" >
+										<Grid item xs={12} sm={8} md={9} lg={10} sx={{ textAlign: { xs: "center", sm: "left" } }}>
+											<span>{module.title}</span>
+										</Grid>
+										<Grid className="btncricle" item xs={12} sm={4} md={3} lg={2} sx={{ textAlign:"center" }}>
+											<Tooltip title="Más información" arrow>
+												<Button
+													onClick={(event) => {
+														event.preventDefault()
+														event.stopPropagation()
+														handleClick(module.id)}
+													}
+													style={{
+														backgroundColor: activeModule === module.id ? "#e84a5f" : "unset",
+														border: "2px solid #fff",
+														padding: "10px",
+													}}
+												>
+													<img src={iconoinfo} alt="Información" />
+												</Button>
+											</Tooltip>
+										</Grid>
+									</Grid>
+								</Link>
                             </div>
                         </div>
                     ))}

--- a/src/pages/home/Carrousel.jsx
+++ b/src/pages/home/Carrousel.jsx
@@ -86,39 +86,39 @@ function Carrousel({ setActiveTab, setShowQueEs }) {
                 </Grid>
                 <Slider {...settings}>
                     {availableModules.map((module) => (
-                        <div key={module.id} className="ModuloPrincipal" style={{ height: "auto", padding: 12 }}>
-                            <div className="moduactivo active" >
+						<div key={module.id} className="ModuloPrincipal" style={{ height: "auto", padding: 12 }}>
+							<div className="moduactivo active" >
 								<Link to={module.link}>
-									<Tooltip title="Haz clic para explorar" arrow>
-										<img className="Modulos" src={module.image} alt={module.title} style={{ width: "65%", height: "auto", cursor: "pointer" }} />
-									</Tooltip>
-
-									<Grid container alignItems="center" className="contenedor activo" >
-										<Grid item xs={12} sm={8} md={9} lg={10} sx={{ textAlign: { xs: "center", sm: "left" } }}>
-											<span>{module.title}</span>
-										</Grid>
-										<Grid className="btncricle" item xs={12} sm={4} md={3} lg={2} sx={{ textAlign:"center" }}>
-											<Tooltip title="Más información" arrow>
-												<Button
-													onClick={(event) => {
-														event.preventDefault()
-														event.stopPropagation()
-														handleClick(module.id)}
-													}
-													style={{
-														backgroundColor: activeModule === module.id ? "#e84a5f" : "unset",
-														border: "2px solid #fff",
-														padding: "10px",
-													}}
-												>
-													<img src={iconoinfo} alt="Información" />
-												</Button>
-											</Tooltip>
-										</Grid>
-									</Grid>
+									<img className="Modulos" src={module.image} alt={module.title} style={{ width: "65%", height: "auto", cursor: "pointer" }} />
 								</Link>
-                            </div>
-                        </div>
+
+								<Grid container alignItems="center" className="contenedor activo" >
+									<Grid item xs={12} sm={8} md={9} lg={10} sx={{ textAlign: { xs: "center", sm: "left" }, minHeight:"54px", display:"flex"}}>
+										<Link to={module.link} style={{alignSelf:"center", padding:"5px 0"}}>
+											<span>{module.title}</span>
+										</Link>
+									</Grid>
+
+									<Grid className="btncricle" item xs={12} sm={4} md={3} lg={2} sx={{ textAlign:"center" }}>
+										<Tooltip title="Más información" arrow>
+											<Button
+												onClick={(event) => {
+													event.preventDefault()
+													handleClick(module.id)}
+												}
+												style={{
+													backgroundColor: activeModule === module.id ? "#e84a5f" : "unset",
+													border: "2px solid #fff",
+													padding: "10px",
+												}}
+											>
+												<img src={iconoinfo} alt="Información" />
+											</Button>
+										</Tooltip>
+									</Grid>
+								</Grid>
+							</div>
+						</div>
                     ))}
                 </Slider>
             </Container>

--- a/src/pages/home/TabsComponent.jsx
+++ b/src/pages/home/TabsComponent.jsx
@@ -281,9 +281,9 @@ function Tabsmodulos({ activeTab, setActiveTab }) {
                             </Box>
                         ) : (
                             <Box sx={{ display: "flex", flexDirection: "column", mt: 2 }}>
-                                <Tabs orientation="vertical" variant="scrollable" value={subTab} onChange={handleSubTabChange} sx={{ marginTop: { xs: "77px", sm: "23px" }, width: { xs: "100%", sm: 290 }, alignSelf: "center" }}>
+                                <Tabs orientation="vertical" variant="scrollable" value={subTab} onChange={handleSubTabChange} sx={{ marginTop: { xs: "77px", sm: "23px" }, width: { xs: "100%", sm: 290 }, alignSelf: "start" }}>
                                     {categories[activeTab].subcategories.map((sub, index) => (
-                                        <Tab key={index} label={sub.title} />
+                                        <Tab key={index} label={sub.title} sx={{ border: "none !important"}}/>
                                     ))}
                                 </Tabs>
 


### PR DESCRIPTION
## 🛠️ Changes
- Fija el estado de las tarjetas de home, y las interacciones planteadas, clic en la tarjeta, va al módulo, clic en la i, muestra los tabs con la descripción del módulo
- Soluciona la importación de Lato a todo el proyecto (odio el important, pero tocaba subir la especificidad para sobre escribir la configuración de fuentes de MUI, confirmé con Efrén que esa es la única fuente del proyecto)
- soluciona un bailecito todo pendejo que había en los tabs al hacer rollover en las etiquetas y el movimiento cuando la cantidad de texto en la descripción cambiaba

## 📝 Associated issues

Soluciona el ticket [LIB-353](https://linear.app/biodev/issue/LIB-353/hotfix-sobre-el-carrusel-del-home)

## 🤔 Considerations

Aunque los cambios no deberían afectar otras partes, recomiendo revisar en diferentes navegadores, pues en mi computador no presentaba el problema de las fuentes, pero en webkit y en firefox de windows era donde no estaba tomando lato.