### PR TITLE
Update install & build job for develop

### DIFF
--- a/.github/workflows/deploy_dev_stg.yml
+++ b/.github/workflows/deploy_dev_stg.yml
@@ -36,10 +36,8 @@ jobs:
 
       - name: install & build
         run: |
-          pnpm -r install
-          pnpm -r build-pkg
           pnpm install
-          pnpm build
+          pnpm build:careless
 
       - name: Deploy to Azure WebApp
         uses: azure/webapps-deploy@v2

--- a/.github/workflows/deploy_dev_stg.yml
+++ b/.github/workflows/deploy_dev_stg.yml
@@ -13,11 +13,11 @@ on:
         required: true
 env:
   AZURE_WEBAPP_NAME: biotablero-frontend
-  REACT_APP_ENVIRONMENT:  ${{ inputs.app_env }}
-  REACT_APP_SEARCH_BACKEND_URL: ${{ vars.SEARCH_BACKEND_URL }}
-  REACT_APP_BACKEND_URL: ${{ vars.BACKEND_URL }}
-  REACT_APP_BACKEND_KEY: ${{ secrets.BACKEND_KEY }}
-  REACT_APP_GA_TRACKING_ID: ${{ vars.GA_TRACKING_ID }}
+  VITE_ENVIRONMENT:  ${{ inputs.app_env }}
+  VITE_SEARCH_BACKEND_URL: ${{ vars.SEARCH_BACKEND_URL }}
+  VITE_BACKEND_URL: ${{ vars.BACKEND_URL }}
+  VITE_BACKEND_KEY: ${{ secrets.BACKEND_KEY }}
+  VITE_GA_TRACKING_ID: ${{ vars.GA_TRACKING_ID }}
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
## 🛠️ Changes
- Remove the call to deprecated scripts. Add the call to the build script without performing TypeScript checks (upon completion of the component update).

## 📝 Associated issues
Resolves LIB-395

## 🤔 Considerations
- Since the action only runs when you push to develop, it's possible to test it locally by installing **act**: https://www.freecodecamp.org/news/how-to-run-github-actions-locally/
- Once the component update is complete, the call to "build:careless" should be changed to "build"

## ✅ Checks
- 