### PR TITLE
Soluciona el problema en la remoción del tooltip sobre los mapas tras la actualización de chromium 144

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biotablero",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "packageManager": "pnpm@8.15.1",
   "scripts": {
     "start": "PORT=5000 serve -s build",

--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -312,6 +312,12 @@ class Search extends Component {
       scibaja_moderada: 'Bajo Moderado',
     };
     const feature = event.target;
+
+    if (this.currentTooltip) {
+      this.currentTooltip.remove();
+      this.currentTooltip = null;
+    }
+
     let changeStyle = true;
     const optionsTooltip = { sticky: true };
     switch (layerName) {
@@ -355,6 +361,12 @@ class Search extends Component {
         changeStyle = false;
         break;
     }
+
+    this.currentTooltip = L.tooltip(optionsTooltip)
+      .setLatLng(event.latlng)
+      .setContent(content)
+      .addTo(feature._map);
+
     if (changeStyle) {
       feature.setStyle({
         weight: 1,


### PR DESCRIPTION
## 🛠️ Changes
Con la actualización de Chromium 144, se detectó un comportamiento rarito en la eliminación de elementos del DOM; parece que el navegador se puso más estricto con el ciclo de vida de los nodos, lo que causaba que los tooltips se acumularan al hacer rollover sobre los shapes (me perdonan el espanglish). Al inicio se trató de corregir usando bindTooltip, pero el comportamiento era muy errático: o solo mostraba el tooltip en el centroide del shape o de plano no hacía un culo porque el "bindeo" constante generaba un conflicto en las instancias de los tooltips.

@cgalvist encontró una solución que ayudó un montón para determinar la ubicación del problema y su naturaleza, confirmando que el lío era la permanencia del elemento en el tooltipPane. Aunque esa solución inicial funcionaba, tenía el detalle de que iteraba sobre absolutamente todas las capas del mapa para encontrar el pane y limpiarlo en cada movimiento del mouse... Para que la solución fuera menos paila con la CPU, decidí crear dentro de la clase Search la propiedad currentTooltip. De esta forma, manejamos una referencia única que nos permite forzar el redibujo y la destrucción del elemento anterior de manera atómica, garantizando que el DOM se limpie así llueva truene o relampaguee.

## 📝 Associated issues
[resolves LIB-473](https://linear.app/biodev/issue/LIB-473/crear-hotfix-con-ajustes-en-mapas)

## 🤔 Considerations
Aunque creo que no vamos a tener este problema con la rama develop, apenas sea posible la presentacion de las capas dentro del search toca hacer esa prueba