### PR TITLE
Corrige los verbos http de las peticiones al back

### DIFF
--- a/src/pages/monitoring/api/monitoringAPI.ts
+++ b/src/pages/monitoring/api/monitoringAPI.ts
@@ -451,6 +451,7 @@ export async function uploadImages(
 
     const formData = new FormData();
     formData.append("formFile", image.file);
+
     const res = await monitoringAPI({
       type: "post",
       endpoint: image.path,

--- a/src/pages/monitoring/outlets/initiativesAdmin/InitiativeCard.tsx
+++ b/src/pages/monitoring/outlets/initiativesAdmin/InitiativeCard.tsx
@@ -160,7 +160,10 @@ export function InitiativeCard({
       general,
       locations,
       contacts,
-      users,
+
+      // TODO: EL tipo de usuario está definido en otra rama, cuando se integre
+      // es necesario actualizar el valor de comparación del usuario
+      users: users.filter((user) => user.level.id === 1),
       images: { imageUrl, bannerUrl },
     };
   }, [cardInfo]);

--- a/src/pages/monitoring/outlets/initiativesAdmin/InitiativeDataForm.tsx
+++ b/src/pages/monitoring/outlets/initiativesAdmin/InitiativeDataForm.tsx
@@ -80,8 +80,8 @@ export function InitiativeDataForm({ onSuccess }: { onSuccess: () => void }) {
       const payload = { ...cleanGeneral, ...rest };
 
       const res = await monitoringAPI<InitiativeFullInfo>({
-        type: "put",
-        endpoint: "initiative",
+        type: "post",
+        endpoint: "Initiative",
         options: {
           data: payload,
           headers: {

--- a/src/pages/monitoring/outlets/initiativesAdmin/initiativeCard/FormListUpdater.tsx
+++ b/src/pages/monitoring/outlets/initiativesAdmin/initiativeCard/FormListUpdater.tsx
@@ -171,7 +171,7 @@ export function FormListUpdater<T, R extends object>({
       const itemId = getItemId(updateItem);
 
       const res = await monitoringAPI<T>({
-        type: itemId ? "post" : "put",
+        type: itemId ? "put" : "post",
         endpoint: itemId ? `${backEndpoint}/${itemId}` : backEndpoint,
         options: {
           data: { ...itemInfo, initiativeId: initiativeId ?? "" },

--- a/src/pages/monitoring/outlets/initiativesAdmin/initiativeCard/GeneralInfoUpdater.tsx
+++ b/src/pages/monitoring/outlets/initiativesAdmin/initiativeCard/GeneralInfoUpdater.tsx
@@ -89,7 +89,7 @@ export function GeneralInfoUpdater({
       ) as Record<string, string>;
 
       const res = await monitoringAPI({
-        type: "post",
+        type: "put",
         endpoint: `${backEndpoint}/${initiativeId}`,
         options: {
           data: payload,

--- a/src/pages/monitoring/outlets/initiativesAdmin/initiativeDataForm/GeneralInfo.tsx
+++ b/src/pages/monitoring/outlets/initiativesAdmin/initiativeDataForm/GeneralInfo.tsx
@@ -293,6 +293,50 @@ export function GeneralInfoInput<T extends GeneralInfo>({
       <div className="flex flex-wrap [&>div]:flex-[1_0_250px] gap-2 items-start">
         <div>
           <LabelAndErrors
+            errID="errors_objective"
+            htmlFor="objective"
+            validationErrors={inputErr.objective ?? []}
+          >
+            {uiText.initiative.module.general.field.objective}{" "}
+            <i>{uiText.initiative.module.general.field.objectiveHelper}</i>
+          </LabelAndErrors>
+
+          <InputGroup>
+            <TextareaAutosize
+              data-slot="input-group-control"
+              className="flex field-sizing-content min-h-16 w-full resize-none rounded-md bg-transparent px-3 py-2.5 text-base transition-[color,box-shadow] outline-none md:text-sm"
+              id="objective"
+              name="objective"
+              placeholder={
+                uiText.initiative.module.general.field.objectiveHelper
+              }
+              value={generalInfo.objective}
+              onChange={(e) => setGeneralInfoItem("objective")(e.target.value)}
+              onBlur={objectiveOnBlur}
+              maxLength={INITIAVIVE_OBJECTIVE_MAX_LENGTH}
+              aria-invalid={inputErr.objective !== undefined}
+              aria-required="true"
+              aria-describedby={
+                inputErr.objective ? "errors_objective" : undefined
+              }
+              rows={10}
+            />
+            <InputGroupAddon
+              align="block-end"
+              className={`${inputWarnColor(
+                generalInfo.objective,
+                INITIAVIVE_OBJECTIVE_MAX_LENGTH,
+                0.95,
+              )} flex-row-reverse`}
+            >
+              {`${generalInfo.objective.length} / ${INITIAVIVE_OBJECTIVE_MAX_LENGTH}
+		  `}
+            </InputGroupAddon>
+          </InputGroup>
+        </div>
+
+        <div>
+          <LabelAndErrors
             errID="errors_influenceArea"
             htmlFor="influenceArea"
             validationErrors={inputErr.influenceArea ?? []}
@@ -332,50 +376,6 @@ export function GeneralInfoInput<T extends GeneralInfo>({
               )} flex-row-reverse`}
             >
               {`${generalInfo.influenceArea.length} / ${INITIAVIVE_INFLUENCE_MAX_LENGTH}
-		  `}
-            </InputGroupAddon>
-          </InputGroup>
-        </div>
-
-        <div>
-          <LabelAndErrors
-            errID="errors_objective"
-            htmlFor="objective"
-            validationErrors={inputErr.objective ?? []}
-          >
-            {uiText.initiative.module.general.field.objective}{" "}
-            <i>{uiText.initiative.module.general.field.objectiveHelper}</i>
-          </LabelAndErrors>
-
-          <InputGroup>
-            <TextareaAutosize
-              data-slot="input-group-control"
-              className="flex field-sizing-content min-h-16 w-full resize-none rounded-md bg-transparent px-3 py-2.5 text-base transition-[color,box-shadow] outline-none md:text-sm"
-              id="objective"
-              name="objective"
-              placeholder={
-                uiText.initiative.module.general.field.objectiveHelper
-              }
-              value={generalInfo.objective}
-              onChange={(e) => setGeneralInfoItem("objective")(e.target.value)}
-              onBlur={objectiveOnBlur}
-              maxLength={INITIAVIVE_OBJECTIVE_MAX_LENGTH}
-              aria-invalid={inputErr.objective !== undefined}
-              aria-required="true"
-              aria-describedby={
-                inputErr.objective ? "errors_objective" : undefined
-              }
-              rows={10}
-            />
-            <InputGroupAddon
-              align="block-end"
-              className={`${inputWarnColor(
-                generalInfo.objective,
-                INITIAVIVE_OBJECTIVE_MAX_LENGTH,
-                0.95,
-              )} flex-row-reverse`}
-            >
-              {`${generalInfo.objective.length} / ${INITIAVIVE_OBJECTIVE_MAX_LENGTH}
 		  `}
             </InputGroupAddon>
           </InputGroup>

--- a/src/pages/monitoring/outlets/initiativesAdmin/layout/uiText.ts
+++ b/src/pages/monitoring/outlets/initiativesAdmin/layout/uiText.ts
@@ -61,7 +61,7 @@ export const uiText = {
         minAmount: (
           amount: number,
         ) => `Siempre deben haber al menos ${amount} elemento
-            ${amount > 1 && "s"}.
+            ${amount > 1 ? "s" : ""}.
 		 `,
       },
     },

--- a/src/pages/monitoring/outlets/initiativesManagement/hooks/useInitiativeJoinRequest.tsx
+++ b/src/pages/monitoring/outlets/initiativesManagement/hooks/useInitiativeJoinRequest.tsx
@@ -167,7 +167,7 @@ export function useInitiativeJoinRequest(initiativesIds: number[]) {
     newStatus: "Approved" | "Rejected",
   ) => {
     const res = await monitoringAPI({
-      type: "post",
+      type: "put",
       endpoint: `JoinRequest/${requestId}?requestStatus=${newStatus}`,
     });
 


### PR DESCRIPTION
## 🛠️ Changes
Es un PR pequeño con una recomendación grande al final...

Corrige los verbos HTTP `PUT` y `POST` que venían trocados desde el back. De paso, en la revisión, pulí un par de cositas que vi en el formulario, como el filtrado de los líderes en la lista de actualización (que no estaba filtrando del todo) y la consistencia en la presentación de la información general en la tarjeta: estaba "Objetivo - Área de influencia", mientras que en el formulario de actualización estaba al revés.

Vi otras cosas que no incluyo aquí para no alargar el ticket ni su revisión (más que nada de organizar y separar en archivos las API calls, que ya son muchas y se está volviendo complejo ubicarlas), creo que eso lo podré hacer dentro del ticket de incorporación del diccionario lista de errores, ya que ese toca esa parte.


## 📝 Associated issues
resolves [LIB-462](https://linear.app/biodev/issue/LIB-462/corregir-verbos-http-de-monitoreo-comunitario-frontend)

## 🤔 Considerations
Este PR es bien cortico y pido una mano con la revisión, pues en este momento hay dos tickets en desarrollo que tienen los verbos mixtos (unos correctos para trabajar con el backend más reciente, mientras que otros siguen atados al chascarrillo del back viejo). No me parece bonito hacer los PR de esos tickets teniendo los verbos revueltos, entonces necesito éste para actualizar esas ramas y poderlas subir melitas.

Que gracias