### PR TITLE
Enable maps to current existing metrics in develop

### DIFF
--- a/src/core/composites/charts/SmallBars.tsx
+++ b/src/core/composites/charts/SmallBars.tsx
@@ -71,6 +71,7 @@ export function SmallBarsElement({
   keys,
   tooltips,
   height = 250,
+  selectedIndexValue: SIVInput = "",
   colors,
   onClickHandler,
   groupMode = "stacked",
@@ -83,7 +84,7 @@ export function SmallBarsElement({
   axisX = { enabled: false, legend: "", format: ".2f", tickValues: undefined },
 }: SmallBarsProps) {
   const [selectedIndexValue, setSelectedIndexValue] =
-    useState<SmallBarsState>("");
+    useState<SmallBarsState>(SIVInput);
 
   const transformData = (rawData: Array<SmallBarsData>) => {
     const transformedData = rawData.map((element) => {

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -111,15 +111,16 @@ export function Search() {
 
       try {
         const areaPolygon = await SearchAPI.requestAreaPolygon(geojson);
-        const areaBasic: AreaIdBasic = {
-          id: areaPolygon.polygon_id,
-          name: "polígono",
-          area_type: searchState.areaType!,
-        };
 
         const areaInfo = await SearchAPI.requestAreaInfo(
           areaPolygon.polygon_id,
         );
+        const areaBasic: AreaIdBasic = {
+          id: areaPolygon.polygon_id,
+          name: "polígono",
+          area: areaInfo.area,
+          area_type: searchState.areaType!,
+        };
 
         searchDispatch({
           type: SearchUpdated.CONSOLE_DRAW,

--- a/src/pages/search/api/backendAPI.ts
+++ b/src/pages/search/api/backendAPI.ts
@@ -7,12 +7,7 @@ import {
   DPC,
   timelinePAConn,
 } from "pages/search/types/connectivity";
-import {
-  currentHFValue,
-  currentHFCategories,
-  hfPersistence,
-  hfTimeline,
-} from "pages/search/types/humanFootprint";
+import { hfPersistence, hfTimeline } from "pages/search/types/humanFootprint";
 import {
   helperText,
   textResponse,
@@ -193,36 +188,7 @@ class BackendAPI {
   /** HUMAN FOOTPRINT */
   /** *************** */
   /**
-   * Get the current human footprint value in the given area.
-   *
-   * @param {String} areaType area type id, f.e. "ea", "states"
-   * @param {Number | String} areaId area id to request, f.e. "CRQ", 24
-   *
-   * @return {Object} Object with value and category for the current human footprint
-   */
-  static requestCurrentHFValue(
-    areaType: string,
-    areaId: string | number,
-  ): Promise<currentHFValue> {
-    return BackendAPI.makeGetRequest(`${areaType}/${areaId}/hf/current/value`);
-  }
 
-  /**
-   * Get the current human footprint data by categories in the given area.
-   *
-   * @param {String} areaType area type id, f.e. "ea", "states"
-   * @param {Number | String} areaId area id to request, f.e. "CRQ", 24
-   *
-   * @return {Promise<Array>} Array of objects with data for the current human footprint
-   */
-  static requestCurrentHFCategories(
-    areaType: string,
-    areaId: string | number,
-  ): Promise<Array<currentHFCategories>> {
-    return BackendAPI.makeGetRequest(
-      `${areaType}/${areaId}/hf/current/categories`,
-    );
-  }
 
   /**
    * Get the persistence of human footprint data in the given area.
@@ -599,25 +565,6 @@ class BackendAPI {
     return {
       request: BackendAPI.makeGetRequest(
         `connectivity/se/layer?areaType=${areaType}&areaId=${areaId}&seType=${seType}`,
-        { cancelToken: source.token },
-      ),
-      source,
-    };
-  }
-
-  /**
-   * Get the geometry associated for the current human footprint in the given area.
-   *
-   * @param {String} areaType area type id, f.e. "ea", "states"
-   * @param {Number | String} areaId area id to request, f.e. "CRQ", 24
-   *
-   * @return {ShapeAPIObject} layer object to be loaded in the map
-   */
-  static requestCurrentHFLayer(areaType: string, areaId: number | string) {
-    const source = axios.CancelToken.source();
-    return {
-      request: BackendAPI.makeGetRequest(
-        `${areaType}/${areaId}/hf/layers/current/categories`,
         { cancelToken: source.token },
       ),
       source,

--- a/src/pages/search/api/backendAPI.ts
+++ b/src/pages/search/api/backendAPI.ts
@@ -18,7 +18,7 @@ import {
   textResponse,
   textsObject,
 } from "pages/search/types/texts";
-import { Coverage, SEPAData, seDetails } from "pages/search/types/ecosystems";
+import { SEPAData, seDetails } from "pages/search/types/ecosystems";
 import {
   concentration,
   gaps,
@@ -351,45 +351,6 @@ class BackendAPI {
     return BackendAPI.makeGetRequest(
       `/pa?areaType=${areaType}&areaId=${areaId}`,
     );
-  }
-
-  /**
-   * Get coverage area by selected area
-   * @param {String} areaType area type id, f.e. "ea", "states"
-   * @param {Number | String} areaId area id to request, f.e. "CRQ", 24
-   */
-  static requestCoverage(
-    areaType: string,
-    areaId: string | number,
-  ): Promise<Array<Coverage>> {
-    return BackendAPI.makeGetRequest(
-      `ecosystems/coverage?areaType=${areaType}&areaId=${areaId}`,
-    );
-  }
-
-  /**
-   * Get the coverage layer divided by categories in a given area
-   *
-   * @param {String} areaType area type id, f.e. "ea", "states"
-   * @param {Number | String} areaId area id to request, f.e. "CRQ", 24
-   * @param {String} coverageType coverage category
-   *
-   * @return {Promise<RasterAPIObject>} layer object to be loaded in the map
-   */
-  static requestCoveragesLayer(
-    areaType: string,
-    areaId: number | string,
-    coverageType: string,
-  ) {
-    const source = axios.CancelToken.source();
-    return {
-      request: BackendAPI.makeGetRequest(
-        `ecosystems/coverage/layer?areaType=${areaType}&areaId=${areaId}&coverageType=${coverageType}`,
-        { cancelToken: source.token, responseType: "arraybuffer" },
-        true,
-      ),
-      source,
-    };
   }
 
   /**

--- a/src/pages/search/api/backendAPI.ts
+++ b/src/pages/search/api/backendAPI.ts
@@ -26,7 +26,7 @@ import {
   targetOrPortfolio,
 } from "pages/search/types/portfolios";
 import { geofenceDetails } from "pages/search/types/dashboard";
-import { RasterAPIObject, ShapeAPIObject } from "pages/search/types/api";
+import { ShapeAPIObject } from "pages/search/types/api";
 
 class BackendAPI {
   /** ****** */
@@ -188,7 +188,6 @@ class BackendAPI {
   /** HUMAN FOOTPRINT */
   /** *************** */
   /**
-
 
   /**
    * Get the persistence of human footprint data in the given area.

--- a/src/pages/search/api/layerAPI.ts
+++ b/src/pages/search/api/layerAPI.ts
@@ -1,0 +1,32 @@
+import axios from "axios";
+import { BlobAPIObject } from "pages/search/types/api";
+
+class LayerAPI {
+  /**
+   * Get layer image data
+   * @param url Layer image url
+   * @returns Blob image data
+   */
+  static getLayerData(response: { layer: string }): BlobAPIObject {
+    const source = axios.CancelToken.source();
+    return {
+      request: axios
+        .get(response.layer, {
+          responseType: "blob",
+        })
+        .then((res) => res.data)
+        .catch((error) => {
+          if (axios.isCancel(error)) {
+            return Promise.resolve("request canceled");
+          }
+          let message = "Bad GET response. Try later";
+          if (error.response) message = error.response.status;
+          if (error.request && error.request.statusText === "")
+            message = "no-data-available";
+          return Promise.reject(message);
+        }),
+      source: source,
+    };
+  }
+}
+export default LayerAPI;

--- a/src/pages/search/api/searchAPI.ts
+++ b/src/pages/search/api/searchAPI.ts
@@ -108,27 +108,6 @@ class SearchAPI {
     };
   }
 
-  /**
-   * Get layer image data
-   * @param url Layer image url
-   * @returns Blob image data
-   */
-  static getLayerData(response: { layer: string }): Promise<Blob> {
-    return axios
-      .get(response.layer, {
-        responseType: "blob",
-      })
-      .then((response) => {
-        return response.data;
-      })
-      .catch((error) => {
-        let message = "Bad GET response. Try later";
-        if (error.request && error.request.statusText === "")
-          message = "no-data-available";
-        return Promise.reject(message);
-      });
-  }
-
   /** ************** */
   /** BASE FUNCTIONS */
   /** ************** */

--- a/src/pages/search/api/searchAPI.ts
+++ b/src/pages/search/api/searchAPI.ts
@@ -96,13 +96,13 @@ class SearchAPI {
   static requestMetricsLayer(
     metricId: MetricsTypes,
     itemId: string,
-    category: number,
+    class_id: string,
     polygonId: number,
   ): RasterAPIObject {
     const source = axios.CancelToken.source();
     return {
       request: SearchAPI.makeGetRequest(
-        `metrics/${metricId}/layer?item_id=${itemId}&polygon_id=${polygonId}&category=${category}`,
+        `metrics/${metricId}/layer?item_id=${itemId}&polygon_id=${polygonId}&class_id=${class_id}`,
       ),
       source: source,
     };

--- a/src/pages/search/dashboard/Ecosystems.tsx
+++ b/src/pages/search/dashboard/Ecosystems.tsx
@@ -30,6 +30,7 @@ type EcosystemsState = {
   showInfoMain: boolean;
   infoShown: Set<string>;
   period: string;
+  classes: Set<string>;
 
   coverageData: SmallStackedBarData[];
 
@@ -68,6 +69,7 @@ const initialState: EcosystemsState = {
   showInfoMain: false,
   infoShown: new Set(),
   period: "",
+  classes: new Set(),
 
   coverageData: [],
 
@@ -99,6 +101,7 @@ type EcosystemsAction =
   | { type: "TOGGLE_MAIN_INFO" }
   | { type: "TOGGLE_SECTION_INFO"; payload: string }
   | { type: "SET_PERIOD"; payload: string }
+  | { type: "SET_CLASSES"; payload: Set<string> }
   | { type: "SET_COVERAGE_DATA"; payload: SmallStackedBarData[] }
   | { type: "SET_LAYERS"; payload: RasterLayer[] }
   | { type: "SET_ACTIVE_SE"; payload: string }
@@ -130,6 +133,9 @@ function ecosystemsReducer(
 
     case "SET_PERIOD":
       return { ...state, period: action.payload };
+
+    case "SET_CLASSES":
+      return { ...state, classes: action.payload };
 
     case "SET_COVERAGE_DATA":
       return { ...state, coverageData: action.payload };
@@ -175,6 +181,7 @@ export function Ecosystems() {
     showInfoMain,
     infoShown,
     period,
+    classes,
     coverageData,
     layers,
     activeSE,
@@ -196,7 +203,7 @@ export function Ecosystems() {
       }
 
       controller
-        .getCoveragesLayers(layerPeriod)
+        .getCoveragesLayers(layerPeriod, classes)
         .then((layersRes) => {
           dispatch({ type: "SET_LAYERS", payload: layersRes });
           context.setRasterLayers(layersRes);
@@ -225,8 +232,13 @@ export function Ecosystems() {
 
     SearchAPI.requestMetricsValues<"coverage">("coverage", Number(areaIdId))
       .then((res) => {
-        const obtainedPeriod = res?.id ?? "";
+        const { id, ...classes } = res;
+        const obtainedPeriod = id ?? "";
         dispatch({ type: "SET_PERIOD", payload: obtainedPeriod });
+        dispatch({
+          type: "SET_CLASSES",
+          payload: new Set(Object.keys(classes)),
+        });
 
         dispatch({
           type: "SET_COVERAGE_DATA",

--- a/src/pages/search/dashboard/Ecosystems.tsx
+++ b/src/pages/search/dashboard/Ecosystems.tsx
@@ -1,11 +1,8 @@
-import { useEffect, useContext, useCallback, useReducer } from "react";
+import { useEffect, useContext, useReducer } from "react";
 
 import InfoIcon from "@mui/icons-material/Info";
 import { ShortInfo } from "@composites/ShortInfo";
 import { IconTooltip } from "@ui/Tooltips";
-import TextBoxes from "@ui/TextBoxes";
-
-import { transformCoverageValues } from "pages/search/dashboard/ecosystems/transformData";
 
 import {
   SearchLegacyCTX,
@@ -13,15 +10,14 @@ import {
 } from "pages/search/hooks/SearchContext";
 
 import BackendAPI from "pages/search/api/backendAPI";
-import SearchAPI from "pages/search/api/searchAPI";
 import { MessageWrapperType } from "@composites/charts/withMessageWrapper";
 import { SEPAData } from "pages/search/types/ecosystems";
 import { EcosystemsController } from "pages/search/dashboard/EcosystemsController";
 import { RasterLayer } from "pages/search/types/layers";
 
 import { Coverage } from "pages/search/dashboard/ecosystems/Coverage";
-import { ProtectedAreas } from "pages/search/dashboard/ecosystems/ProtectedAreas";
-import { StrategicEcosystems } from "pages/search/dashboard/ecosystems/StrategicEcosystems";
+// import { ProtectedAreas } from "pages/search/dashboard/ecosystems/ProtectedAreas";
+// import { StrategicEcosystems } from "pages/search/dashboard/ecosystems/StrategicEcosystems";
 import { SmallStackedBarData } from "@composites/charts/SmallStackedBar";
 
 type TextsContent = { info: string; cons: string; meto: string; quote: string };
@@ -29,8 +25,6 @@ type TextsContent = { info: string; cons: string; meto: string; quote: string };
 type EcosystemsState = {
   showInfoMain: boolean;
   infoShown: Set<string>;
-  period: string;
-  classes: Set<string>;
 
   coverageData: SmallStackedBarData[];
 
@@ -45,7 +39,6 @@ type EcosystemsState = {
 
   SEAreas: SEPAData[];
   SETotalArea: number;
-  activeSE: string;
 
   layers: RasterLayer[];
 
@@ -68,8 +61,6 @@ type TextSection = keyof EcosystemsState["texts"];
 const initialState: EcosystemsState = {
   showInfoMain: false,
   infoShown: new Set(),
-  period: "",
-  classes: new Set(),
 
   coverageData: [],
 
@@ -79,7 +70,6 @@ const initialState: EcosystemsState = {
 
   SEAreas: [],
   SETotalArea: 0,
-  activeSE: "",
 
   layers: [],
 
@@ -100,15 +90,9 @@ const initialState: EcosystemsState = {
 type EcosystemsAction =
   | { type: "TOGGLE_MAIN_INFO" }
   | { type: "TOGGLE_SECTION_INFO"; payload: string }
-  | { type: "SET_PERIOD"; payload: string }
-  | { type: "SET_CLASSES"; payload: Set<string> }
-  | { type: "SET_COVERAGE_DATA"; payload: SmallStackedBarData[] }
-  | { type: "SET_LAYERS"; payload: RasterLayer[] }
-  | { type: "SET_ACTIVE_SE"; payload: string }
-  | {
-      type: "SET_MESSAGE";
-      payload: { key: "cov" | "pa" | "se"; value: MessageWrapperType };
-    }
+  | { type: "COVERAGE_VALUES_SUCCEEDED"; payload: SmallStackedBarData[] }
+  | { type: "COVERAGE_LAYERS_SUCCEEDED"; payload: RasterLayer[] }
+  | { type: "COVERAGE_VALUES_FAILED" }
   | {
       type: "SET_TEXTS";
       payload: { section: keyof EcosystemsState["texts"]; value: TextsContent };
@@ -131,27 +115,25 @@ function ecosystemsReducer(
       return { ...state, infoShown: newSet };
     }
 
-    case "SET_PERIOD":
-      return { ...state, period: action.payload };
+    case "COVERAGE_VALUES_SUCCEEDED":
+      return {
+        ...state,
+        coverageData: action.payload,
+        messages: {
+          ...state.messages,
+          cov: null,
+        },
+      };
 
-    case "SET_CLASSES":
-      return { ...state, classes: action.payload };
-
-    case "SET_COVERAGE_DATA":
-      return { ...state, coverageData: action.payload };
-
-    case "SET_LAYERS":
+    case "COVERAGE_LAYERS_SUCCEEDED":
       return { ...state, layers: action.payload };
 
-    case "SET_ACTIVE_SE":
-      return { ...state, activeSE: action.payload };
-
-    case "SET_MESSAGE":
+    case "COVERAGE_VALUES_FAILED":
       return {
         ...state,
         messages: {
           ...state.messages,
-          [action.payload.key]: action.payload.value,
+          cov: "no-data",
         },
       };
 
@@ -173,89 +155,50 @@ const controller = new EcosystemsController();
 
 export function Ecosystems() {
   const context = useContext(SearchLegacyCTX) as LegacyContextValues;
-  const { areaType, areaId, areaHa } = context;
+  const { areaType, areaId } = context;
 
   const [state, dispatch] = useReducer(ecosystemsReducer, initialState);
 
-  const {
-    showInfoMain,
-    infoShown,
-    period,
-    classes,
-    coverageData,
-    layers,
-    activeSE,
-    messages,
-    texts,
-  } = state;
+  const { showInfoMain, infoShown, coverageData, layers, messages, texts } =
+    state;
 
-  const areaTypeId = areaType?.id;
-  const areaIdId = areaId?.id.toString();
-  const areaIdStr = areaIdId ?? "";
+  if (!areaType || !areaId) {
+    context.setLoadingLayer(false);
+    return;
+  }
 
-  const switchLayer = useCallback(
-    (currentPeriod?: string) => {
-      const layerPeriod = currentPeriod ?? period;
-      if (!layerPeriod) {
-        context.setRasterLayers([]);
-        context.setLoadingLayer(false);
-        return;
-      }
+  const areaTypeId = areaType.id;
+  const areaIdId = areaId.id;
 
-      controller
-        .getCoveragesLayers(layerPeriod, classes)
-        .then((layersRes) => {
-          dispatch({ type: "SET_LAYERS", payload: layersRes });
-          context.setRasterLayers(layersRes);
-          context.setLoadingLayer(false);
-          context.setMapTitle({ name: "Coberturas" });
-        })
-        .catch((e) => {
-          context.setLoadingLayer(false);
-          if (!e.toString().includes("request canceled")) {
-            context.setLayerError?.(e.toString());
-          }
-        });
-    },
-    [period],
-  );
+  controller.setArea(areaTypeId, areaIdId);
 
   useEffect(() => {
     context.setLoadingLayer(true);
 
-    if (!areaTypeId || !areaIdId) {
-      context.setLoadingLayer(false);
-      return;
-    }
-
-    controller.setArea(areaTypeId, areaIdId);
-
-    SearchAPI.requestMetricsValues<"coverage">("coverage", Number(areaIdId))
-      .then((res) => {
-        const { id, ...classes } = res;
-        const obtainedPeriod = id ?? "";
-        dispatch({ type: "SET_PERIOD", payload: obtainedPeriod });
+    controller
+      .getCoverageValues()
+      .then((coverageDataRes) => {
+        controller
+          .getCoveragesLayers()
+          .then((layersRes) => {
+            dispatch({ type: "COVERAGE_LAYERS_SUCCEEDED", payload: layersRes });
+            context.setRasterLayers(layersRes);
+            context.setLoadingLayer(false);
+            context.setMapTitle({ name: "Coberturas" });
+          })
+          .catch((e) => {
+            context.setLoadingLayer(false);
+            if (!e.toString().includes("request canceled")) {
+              context.setLayerError?.(e.toString());
+            }
+          });
         dispatch({
-          type: "SET_CLASSES",
-          payload: new Set(Object.keys(classes)),
+          type: "COVERAGE_VALUES_SUCCEEDED",
+          payload: coverageDataRes,
         });
-
-        dispatch({
-          type: "SET_COVERAGE_DATA",
-          payload: transformCoverageValues(res),
-        });
-        dispatch({
-          type: "SET_MESSAGE",
-          payload: { key: "cov", value: null },
-        });
-
-        switchLayer(obtainedPeriod);
       })
       .catch(() => {
-        dispatch({
-          type: "SET_MESSAGE",
-          payload: { key: "cov", value: "no-data" },
-        });
+        dispatch({ type: "COVERAGE_VALUES_FAILED" });
         context.setLoadingLayer(false);
       });
 
@@ -284,7 +227,7 @@ export function Ecosystems() {
       context.clearLayers();
       controller.cancelActiveRequests();
     };
-  }, [areaTypeId, areaIdId, controller, switchLayer]);
+  }, [areaTypeId, areaIdId]);
 
   /**
    * Toggles the visibility state of the main tooltip.
@@ -300,18 +243,6 @@ export function Ecosystems() {
     dispatch({ type: "TOGGLE_SECTION_INFO", payload: value });
 
   /**
-   * Set active strategic ecosystem graph
-   *
-   * @param {String} se selected strategic ecosystem
-   */
-  const switchActiveSEHandler = (se: string) => {
-    const newVal = activeSE !== se && se !== "" ? se : "";
-    dispatch({ type: "SET_ACTIVE_SE", payload: newVal });
-
-    if (newVal === "") switchLayer();
-  };
-
-  /**
    * Set the selected layer to highlight
    *  @param {string} selectedKey Special Ecosystem type
    */
@@ -322,10 +253,6 @@ export function Ecosystems() {
         selected: layer.id === selectedKey,
       })),
     );
-  };
-
-  const resetActiveSE = () => {
-    if (activeSE) dispatch({ type: "SET_ACTIVE_SE", payload: "" });
   };
 
   return (
@@ -352,9 +279,8 @@ export function Ecosystems() {
           toggleInfo={() => toggleInfo("coverage")}
           texts={texts.coverage}
           messages={messages.cov}
-          areaIdStr={areaIdStr}
+          areaIdStr={`${areaIdId}`}
           onClickGraph={clickOnGraph}
-          resetActiveSE={resetActiveSE}
         />
 
         {/* PROTECTED AREAS */}
@@ -378,13 +304,11 @@ export function Ecosystems() {
           SEAreas={SEAreas}
           SETotalArea={SETotalArea}
           areaHa={areaHa!}
-          activeSE={activeSE}
           infoOpen={infoShown.has("se")}
           toggleInfo={() => toggleInfo("se")}
           texts={texts.se}
           messages={messages.se}
           areaIdStr={areaIdStr}
-          setActiveSE={setActiveSE}
           isLoading={messages.se === "loading"}
           noData={messages.se === "no-data"}
         />

--- a/src/pages/search/dashboard/EcosystemsController.ts
+++ b/src/pages/search/dashboard/EcosystemsController.ts
@@ -1,7 +1,9 @@
 import SearchAPI from "pages/search/api/searchAPI";
+import LayerAPI from "../api/layerAPI";
 import { RasterLayer } from "pages/search/types/layers";
 import { CancelTokenSource } from "axios";
 import { MetricsUtils } from "pages/search/utils/metrics";
+import { transformCoverageValues } from "./ecosystems/transformData";
 
 /**
  * Controller for Ecosystems Component
@@ -9,37 +11,52 @@ import { MetricsUtils } from "pages/search/utils/metrics";
  */
 export class EcosystemsController {
   areaType: string = "";
-  areaId: string = "";
+  areaId: number = 0;
   activeRequests: Map<string, CancelTokenSource> = new Map();
-
+  classes: Set<string> = new Set();
+  itemId: string = "";
   constructor() {}
 
   /**
    * Set area values for the controller
    *  @param {string} areaType Value for the type of area selected
-   *  @param {string} areaId Value for the id of area selected
+   *  @param {number} areaId Value for the id of area selected
    */
-  setArea(areaType: string, areaId: string) {
+  setArea(areaType: string, areaId: number) {
     this.areaType = areaType;
     this.areaId = areaId;
   }
 
   /**
-   * Get the raster layers required for a Coverage type
+   * Get the coverage values for the current area
+   *
+   * @returns { Promise<SmallStackedBarData[]>}
+   */
+  getCoverageValues() {
+    return SearchAPI.requestMetricsValues<"coverage">(
+      "coverage",
+      this.areaId,
+    ).then((res) => {
+      const { id, ...classes } = res;
+      this.itemId = id;
+      this.classes = new Set(Object.keys(classes));
+      return transformCoverageValues(res);
+    });
+  }
+
+  /**
+   * Get the coverage raster layers for the current area
    *
    * @returns { Promise<Array<RasterLayer>> } layers for the categories in the indicated period
    */
-  async getCoveragesLayers(
-    period: string,
-    classes: Set<string>,
-  ): Promise<Array<RasterLayer>> {
+  async getCoveragesLayers(): Promise<Array<RasterLayer>> {
     if (this.areaId) {
       const requests: Array<Promise<{ layer: string }>> = [];
 
-      classes.forEach((classId) => {
+      this.classes.forEach((classId) => {
         const { request, source } = SearchAPI.requestMetricsLayer(
           "coverage",
-          period,
+          this.itemId,
           classId,
           Number(this.areaId),
         );
@@ -49,7 +66,7 @@ export class EcosystemsController {
 
       const res = await Promise.all(requests);
 
-      classes.forEach((classId) => {
+      this.classes.forEach((classId) => {
         this.activeRequests.delete(classId);
       });
 
@@ -58,12 +75,20 @@ export class EcosystemsController {
       }
 
       const layersRequests: Array<Promise<Blob>> = [];
-      res.forEach((response) => {
-        const request = SearchAPI.getLayerData(response);
+      res.forEach((layerObj) => {
+        const { request, source } = LayerAPI.getLayerData(layerObj);
         layersRequests.push(request);
+        this.activeRequests.set(layerObj.layer, source);
       });
 
       const layerResponses = await Promise.all(layersRequests);
+      res.forEach((layerObj) => {
+        this.activeRequests.delete(layerObj.layer);
+      });
+
+      if (res.some((result) => typeof result === "string")) {
+        throw new Error("request canceled");
+      }
 
       const layersBase64Promises: Array<Promise<string>> = [];
 
@@ -74,7 +99,7 @@ export class EcosystemsController {
 
       const layersBase64 = await Promise.all(layersBase64Promises);
 
-      return [...classes].map((classId, index) => ({
+      return [...this.classes].map((classId, index) => ({
         id: classId,
         data: layersBase64[index],
         selected: false,

--- a/src/pages/search/dashboard/EcosystemsController.ts
+++ b/src/pages/search/dashboard/EcosystemsController.ts
@@ -1,7 +1,6 @@
 import SearchAPI from "pages/search/api/searchAPI";
 import { RasterLayer } from "pages/search/types/layers";
 import { CancelTokenSource } from "axios";
-import { coverageKeys } from "pages/search/types/ecosystems";
 import { MetricsUtils } from "pages/search/utils/metrics";
 
 /**
@@ -30,25 +29,28 @@ export class EcosystemsController {
    *
    * @returns { Promise<Array<RasterLayer>> } layers for the categories in the indicated period
    */
-  async getCoveragesLayers(period: string): Promise<Array<RasterLayer>> {
+  async getCoveragesLayers(
+    period: string,
+    classes: Set<string>,
+  ): Promise<Array<RasterLayer>> {
     if (this.areaId) {
       const requests: Array<Promise<{ layer: string }>> = [];
 
-      Object.keys(coverageKeys).forEach((categoryId) => {
+      classes.forEach((classId) => {
         const { request, source } = SearchAPI.requestMetricsLayer(
           "coverage",
           period,
-          coverageKeys[categoryId],
+          classId,
           Number(this.areaId),
         );
         requests.push(request);
-        this.activeRequests.set(categoryId, source);
+        this.activeRequests.set(classId, source);
       });
 
       const res = await Promise.all(requests);
 
-      Object.keys(coverageKeys).forEach((categoryKey) => {
-        this.activeRequests.delete(categoryKey);
+      classes.forEach((classId) => {
+        this.activeRequests.delete(classId);
       });
 
       if (res.some((result) => typeof result === "string")) {
@@ -72,8 +74,8 @@ export class EcosystemsController {
 
       const layersBase64 = await Promise.all(layersBase64Promises);
 
-      return Object.keys(coverageKeys).map((category, index) => ({
-        id: category,
+      return [...classes].map((classId, index) => ({
+        id: classId,
         data: layersBase64[index],
         selected: false,
         paneLevel: 2,

--- a/src/pages/search/dashboard/EcosystemsController.ts
+++ b/src/pages/search/dashboard/EcosystemsController.ts
@@ -39,7 +39,11 @@ export class EcosystemsController {
     ).then((res) => {
       const { id, ...classes } = res;
       this.itemId = id;
-      this.classes = new Set(Object.keys(classes));
+      this.classes = new Set(
+        Object.keys(classes).filter(
+          (classId) => classes[classId as keyof typeof classes] != 0.0,
+        ),
+      );
       return transformCoverageValues(res);
     });
   }
@@ -47,7 +51,7 @@ export class EcosystemsController {
   /**
    * Get the coverage raster layers for the current area
    *
-   * @returns { Promise<Array<RasterLayer>> } layers for the categories in the indicated period
+   * @returns { Promise<Array<RasterLayer>> } layers for the classes in the current area
    */
   async getCoveragesLayers(): Promise<Array<RasterLayer>> {
     if (this.areaId) {

--- a/src/pages/search/dashboard/ecosystems/Coverage.tsx
+++ b/src/pages/search/dashboard/ecosystems/Coverage.tsx
@@ -22,7 +22,7 @@ interface Props {
   messages: MessageWrapperType;
   areaIdStr: string;
   onClickGraph: (id: string) => void;
-  resetActiveSE: () => void;
+  resetActiveSE?: () => void;
 }
 
 export function Coverage({

--- a/src/pages/search/dashboard/ecosystems/ecosystemsBox/EcosystemDetails.tsx
+++ b/src/pages/search/dashboard/ecosystems/ecosystemsBox/EcosystemDetails.tsx
@@ -10,12 +10,7 @@ import {
 } from "pages/search/dashboard/ecosystems/transformData";
 import { matchColor } from "pages/search/utils/matchColor";
 
-import {
-  Coverage,
-  coverageLabels,
-  coverageType,
-  SEPADataExt,
-} from "pages/search/types/ecosystems";
+import { Coverage, SEPADataExt } from "pages/search/types/ecosystems";
 import BackendAPI from "pages/search/api/backendAPI";
 import SmallStackedBar from "@composites/charts/SmallStackedBar";
 import { type MessageWrapperType } from "@composites/charts/withMessageWrapper";
@@ -29,8 +24,9 @@ export interface PAData {
   percentage: number;
 }
 export interface CoverageExt extends Coverage {
-  key: coverageType;
-  label: coverageLabels;
+  //TODO: Fijar tipos correctos o cambiar a necesidad
+  key: any;
+  label: any;
 }
 interface State {
   coverageData: Array<CoverageExt>;

--- a/src/pages/search/dashboard/ecosystems/transformData.ts
+++ b/src/pages/search/dashboard/ecosystems/transformData.ts
@@ -1,8 +1,4 @@
-import {
-  SEPAData,
-  coverageLabels,
-  SEPADataExt,
-} from "pages/search/types/ecosystems";
+import { SEPAData, SEPADataExt } from "pages/search/types/ecosystems";
 import { MetricTypesMap } from "pages/search/types/metrics";
 
 export const transformPAValues = (
@@ -44,13 +40,13 @@ export const transformCoverageValues = (
 ) => {
   if (!rawData) return [];
 
-  const items = [
-    { key: "N", label: "Natural", area: rawData.Natural },
-    { key: "S", label: "Secundaria", area: rawData.Secundaria },
-    { key: "T", label: "Transformada", area: rawData.Transformada },
-  ];
-
-  const totalArea = rawData.Natural + rawData.Secundaria + rawData.Transformada;
+  const { id, ...classes } = rawData;
+  const items = [];
+  let totalArea = 0;
+  for (const [key, value] of Object.entries(classes)) {
+    items.push({ key, label: key, area: value });
+    totalArea += value;
+  }
 
   return items.map((item) => ({
     area: item.area,

--- a/src/pages/search/dashboard/landscape/forest/ForestLossPersistence.tsx
+++ b/src/pages/search/dashboard/landscape/forest/ForestLossPersistence.tsx
@@ -24,7 +24,7 @@ interface State {
   showInfoGraph: boolean;
   forestLP: Array<ForestLPExt>;
   message: MessageWrapperType;
-  forestPersistenceValue: number;
+  currentPersistence: number;
   texts: {
     forestLP: textsObject;
   };
@@ -36,7 +36,7 @@ class ForestLossPersistence extends React.Component<Props, State> {
   mounted = false;
   componentName = "forestLP";
   flpController;
-  currentPeriod = "2016-2021";
+  currentPeriod = "";
 
   constructor(props: Props) {
     super(props);
@@ -45,7 +45,7 @@ class ForestLossPersistence extends React.Component<Props, State> {
       showInfoGraph: true,
       forestLP: [],
       message: "loading",
-      forestPersistenceValue: 0,
+      currentPersistence: 0,
       texts: {
         forestLP: { info: "", cons: "", meto: "", quote: "" },
       },
@@ -55,23 +55,27 @@ class ForestLossPersistence extends React.Component<Props, State> {
 
   componentDidMount() {
     this.mounted = true;
-    const { areaType, areaId, searchType } = this
+    const { areaType, areaId, setLoadingLayer } = this
       .context as LegacyContextValues;
 
-    const areaTypeId = areaType!.id;
-    const areaIdId = areaId!.id.toString();
+    if (!areaType || !areaId) {
+      setLoadingLayer(false);
+      return;
+    }
+
+    const areaTypeId = areaType.id;
+    const areaIdId = areaId.id;
 
     this.flpController.setArea(areaTypeId, areaIdId);
 
-    this.switchLayer(this.currentPeriod);
-
     this.flpController
-      .getForestLPData(this.currentPeriod)
+      .getForestLPData()
       .then((data) => {
+        this.switchLayer(this.currentPeriod);
         if (this.mounted) {
           this.setState({
             forestLP: data.forestLP,
-            forestPersistenceValue: data.forestPersistenceValue,
+            currentPersistence: data.currentPersistence,
             message: null,
           });
         }
@@ -107,7 +111,7 @@ class ForestLossPersistence extends React.Component<Props, State> {
   render() {
     const {
       forestLP,
-      forestPersistenceValue,
+      currentPersistence,
       showInfoGraph,
       message,
       texts,
@@ -149,7 +153,7 @@ class ForestLossPersistence extends React.Component<Props, State> {
                 colorPalettes.default[0],
             }}
           >
-            {`${formatNumber(forestPersistenceValue, 0)} ha `}
+            {`${formatNumber(currentPersistence, 0)} ha `}
           </h5>
         </div>
         <div>
@@ -162,6 +166,7 @@ class ForestLossPersistence extends React.Component<Props, State> {
             tooltips={graphData.tooltips}
             loadStatus={message}
             margin={{
+              left: 100,
               bottom: 50,
             }}
             axisY={{
@@ -189,7 +194,7 @@ class ForestLossPersistence extends React.Component<Props, State> {
                 this.switchLayer(period);
               }
             }}
-            selectedIndexValue={selectedIndex}
+            selectedIndexValue={"2016-2021"}
           />
         </div>
         <TextBoxes

--- a/src/pages/search/dashboard/landscape/forest/ForestLossPersistence.tsx
+++ b/src/pages/search/dashboard/landscape/forest/ForestLossPersistence.tsx
@@ -68,9 +68,11 @@ class ForestLossPersistence extends React.Component<Props, State> {
 
     this.flpController.setArea(areaTypeId, areaIdId);
 
+    setLoadingLayer(true);
     this.flpController
       .getForestLPData()
       .then((data) => {
+        this.currentPeriod = data.forestLP[data.forestLP.length - 1].id;
         this.switchLayer(this.currentPeriod);
         if (this.mounted) {
           this.setState({
@@ -194,7 +196,7 @@ class ForestLossPersistence extends React.Component<Props, State> {
                 this.switchLayer(period);
               }
             }}
-            selectedIndexValue={"2016-2021"}
+            selectedIndexValue={selectedIndex}
           />
         </div>
         <TextBoxes

--- a/src/pages/search/dashboard/landscape/forest/ForestLossPersistenceController.ts
+++ b/src/pages/search/dashboard/landscape/forest/ForestLossPersistenceController.ts
@@ -21,19 +21,20 @@ import { MetricTypesMap } from "pages/search/types/metrics";
 
 interface ForestLPData {
   forestLP: Array<ForestLPExt>;
-  forestPersistenceValue: number;
-  forestLPArea?: number;
+  currentPersistence: number;
 }
 
 export class ForestLossPersistenceController {
   areaType: string = "";
-  areaId: string = "";
+  areaId: number = 0;
   polygon: polygonFeature | null = null;
   activeRequests: Map<string, CancelTokenSource> = new Map();
+  classes: Set<string> = new Set();
+  itemId: string = "";
 
   constructor() {}
 
-  setArea(areaType: string, areaId: string) {
+  setArea(areaType: string, areaId: number) {
     this.areaType = areaType;
     this.areaId = areaId;
   }
@@ -65,63 +66,55 @@ export class ForestLossPersistenceController {
   /**
    * Returns forest LP data and persistence value in a given area
    *
-   * @param latestPeriod string with range of years for latest period
-   * @param searchType string to identify the type of search
-   *
    * @returns Object with forest LP data and persistence value
    */
-  getForestLPData = (latestPeriod: string): Promise<ForestLPData> => {
-    if (this.areaId === "") {
-      throw Error("Area undefined");
-    }
-
+  getForestLPData = (): Promise<ForestLPData> => {
     return SearchAPI.requestMetricsValues<"lossPersistence">(
       "lossPersistence",
-      Number(this.areaId),
+      this.areaId,
     )
       .then((data: MetricTypesMap["lossPersistence"]) => {
-        const mappedData = data.map((item) => {
-          const itemMapped = MetricsUtils.mapLPResponse(item);
-          return MetricsUtils.calcLPAreas(itemMapped);
+        const mappedData = data.map((periodObj) => {
+          const { id, ...classes } = periodObj;
+          // Aquí se guarda el del primero, tenemos que asegurarnos de guardar el
+          // de todos para evitar pedir capas q ue no existen
+          if (this.itemId === "") {
+            this.itemId = id;
+            this.classes = new Set(
+              Object.keys(classes).filter(
+                (classId) => classes[classId as keyof typeof classes] != 0.0,
+              ),
+            );
+          }
+          const totalHa = Object.values(classes).reduce(
+            (prev, curr) => prev + curr,
+            0,
+          );
+          return {
+            id,
+            data: Object.keys(classes).map((classId) => ({
+              area: periodObj[classId as keyof typeof classes],
+              key: classId,
+              percentage:
+                (periodObj[classId as keyof typeof classes] * 100) / totalHa,
+              label: classId,
+            })),
+          };
         });
 
-        const forestLP: Array<ForestLPExt> = mappedData.map((item) => ({
-          id: item.period,
-          data: [
-            {
-              label: "Pérdida",
-              key: "perdida",
-              area: item.loss,
-              percentage: item.percentagesLoss,
-            },
-            {
-              label: "Persistencia",
-              key: "persistencia",
-              area: item.persistence,
-              percentage: item.percentagesPersistence,
-            },
-            {
-              label: "No bosque",
-              key: "no_bosque",
-              area: item.noForest,
-              percentage: item.percentagesNoForest,
-            },
-          ],
-        }));
-
-        const periodData = mappedData.find(
-          ({ period }) => period === latestPeriod,
-        );
-        const forestPersistenceValue = periodData?.persistence ?? 0;
-
-        forestLP.sort((pA, pB) => {
+        mappedData.sort((pA, pB) => {
           const yearA = parseInt(pA.id.substring(0, pA.id.indexOf("-")));
           const yearB = parseInt(pB.id.substring(0, pB.id.indexOf("-")));
           return yearA - yearB;
         });
+        // Ni modo, tocó quemar el Persistencia aquí
+        const currentPersistence =
+          data.find((period) => period.id === mappedData[0].id)?.Persistencia ||
+          0;
+
         return {
-          forestLP,
-          forestPersistenceValue,
+          forestLP: mappedData,
+          currentPersistence,
         };
       })
       .catch(() => {

--- a/src/pages/search/dashboard/landscape/forest/ForestLossPersistenceController.ts
+++ b/src/pages/search/dashboard/landscape/forest/ForestLossPersistenceController.ts
@@ -4,12 +4,8 @@ import {
 } from "@composites/charts/SmallBars";
 import BackendAPI from "pages/search/api/backendAPI";
 import SearchAPI from "pages/search/api/searchAPI";
-import {
-  ForestLPExt,
-  ForestLPRawDataPolygon,
-  ForestLPKeys,
-  ForestLPCategories,
-} from "pages/search/types/forest";
+import LayerAPI from "pages/search/api/layerAPI";
+import { ForestLPExt } from "pages/search/types/forest";
 import { textsObject } from "pages/search/types/texts";
 import { formatNumber } from "@utils/format";
 import { type SmallBarTooltip } from "@composites/charts/SmallBars";
@@ -29,8 +25,7 @@ export class ForestLossPersistenceController {
   areaId: number = 0;
   polygon: polygonFeature | null = null;
   activeRequests: Map<string, CancelTokenSource> = new Map();
-  classes: Set<string> = new Set();
-  itemId: string = "";
+  allClasses: Map<string, Set<string>> = new Map();
 
   constructor() {}
 
@@ -76,16 +71,14 @@ export class ForestLossPersistenceController {
       .then((data: MetricTypesMap["lossPersistence"]) => {
         const mappedData = data.map((periodObj) => {
           const { id, ...classes } = periodObj;
-          // Aquí se guarda el del primero, tenemos que asegurarnos de guardar el
-          // de todos para evitar pedir capas q ue no existen
-          if (this.itemId === "") {
-            this.itemId = id;
-            this.classes = new Set(
+          this.allClasses.set(
+            id,
+            new Set(
               Object.keys(classes).filter(
                 (classId) => classes[classId as keyof typeof classes] != 0.0,
               ),
-            );
-          }
+            ),
+          );
           const totalHa = Object.values(classes).reduce(
             (prev, curr) => prev + curr,
             0,
@@ -109,8 +102,9 @@ export class ForestLossPersistenceController {
         });
         // Ni modo, tocó quemar el Persistencia aquí
         const currentPersistence =
-          data.find((period) => period.id === mappedData[0].id)?.Persistencia ||
-          0;
+          data.find(
+            (period) => period.id === mappedData[mappedData.length - 1].id,
+          )?.Persistencia || 0;
 
         return {
           forestLP: mappedData,
@@ -216,33 +210,41 @@ export class ForestLossPersistenceController {
     if (this.areaId) {
       const requests: Array<Promise<{ layer: string }>> = [];
 
-      Object.values(ForestLPCategories).forEach((value) => {
+      this.allClasses.get(period)!.forEach((classId) => {
         const { request, source } = SearchAPI.requestMetricsLayer(
           "lossPersistence",
           period,
-          value,
-          Number(this.areaId),
+          classId,
+          this.areaId,
         );
         requests.push(request);
-        this.activeRequests.set(`${period}-${value}`, source);
+        this.activeRequests.set(`${period}-${classId}`, source);
       });
 
       const res = await Promise.all(requests);
 
-      ForestLPKeys.forEach((category) => {
-        this.activeRequests.delete(`${period}-${category}`);
+      this.allClasses.get(period)!.forEach((classId) => {
+        this.activeRequests.delete(`${period}-${classId}`);
       });
 
       if (res.some((result) => typeof result === "string")) {
         throw new Error("request canceled");
       }
       const layersRequests: Array<Promise<Blob>> = [];
-      res.forEach((response) => {
-        const request = SearchAPI.getLayerData(response);
+      res.forEach((layerObj) => {
+        const { request, source } = LayerAPI.getLayerData(layerObj);
         layersRequests.push(request);
+        this.activeRequests.set(layerObj.layer, source);
       });
 
       const layerResponses = await Promise.all(layersRequests);
+      res.forEach((layerObj) => {
+        this.activeRequests.delete(layerObj.layer);
+      });
+
+      if (res.some((result) => typeof result === "string")) {
+        throw new Error("request canceled");
+      }
 
       const layersBase64Promises: Array<Promise<string>> = [];
 
@@ -253,12 +255,14 @@ export class ForestLossPersistenceController {
 
       const layersBase64 = await Promise.all(layersBase64Promises);
 
-      let response = ForestLPKeys.map((category, index) => ({
-        id: category,
-        data: layersBase64[index],
-        selected: false,
-        paneLevel: 2,
-      }));
+      let response = [...this.allClasses.get(period)!].map(
+        (classId, index) => ({
+          id: classId,
+          data: layersBase64[index],
+          selected: false,
+          paneLevel: 2,
+        }),
+      );
 
       return response;
     }

--- a/src/pages/search/dashboard/landscape/humanFootprint/CurrentFootprint.tsx
+++ b/src/pages/search/dashboard/landscape/humanFootprint/CurrentFootprint.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useReducer } from "react";
+import { useContext, useEffect, useReducer } from "react";
 
 import InfoIcon from "@mui/icons-material/Info";
 
@@ -11,7 +11,6 @@ import { ShortInfo } from "@composites/ShortInfo";
 import { IconTooltip } from "@ui/Tooltips";
 import { matchColor } from "pages/search/utils/matchColor";
 import BackendAPI from "pages/search/api/backendAPI";
-import SearchAPI from "pages/search/api/searchAPI";
 import TextBoxes from "@ui/TextBoxes";
 
 import {
@@ -24,12 +23,13 @@ import { CurrentFootprintController } from "pages/search/dashboard/landscape/hum
 import { RasterLayer } from "pages/search/types/layers";
 import { textsObject } from "pages/search/types/texts";
 import colorPalettes from "pages/search/utils/colorPalettes";
+import { formatNumber } from "@utils/format";
 
 interface State {
   showInfoGraph: boolean;
   period: string;
   hfCurrent: LargeStackedBarData[];
-  hfCurrentValue: string;
+  hfCurrentValue: number;
   hfCurrentCategory: string;
   message: MessageWrapperType;
   texts: { hfCurrent: textsObject };
@@ -38,17 +38,20 @@ interface State {
 
 type Action =
   | { type: "TOGGLE_INFO_GRAPH" }
-  | { type: "SET_PERIOD"; payload: string }
-  | { type: "SET_HF_CURRENT"; payload: LargeStackedBarData[] }
-  | { type: "SET_MESSAGE"; payload: MessageWrapperType }
-  | { type: "SET_TEXTS"; payload: textsObject }
-  | { type: "SET_LAYERS"; payload: RasterLayer[] };
+  | {
+      type: "AVERAGE_SUCCEEDED";
+      payload: { id: string; average: number; category: string };
+    }
+  | { type: "CURRENTHF_LAYERS_SUCCEEDED"; payload: RasterLayer[] }
+  | { type: "CURRENTHF_VALUES_SUCCEEDED"; payload: LargeStackedBarData[] }
+  | { type: "CURRENTHF_VALUES_FAILED" }
+  | { type: "SET_TEXTS"; payload: textsObject };
 
 const initialState: State = {
   showInfoGraph: true,
   period: "",
   hfCurrent: [],
-  hfCurrentValue: "0",
+  hfCurrentValue: 0,
   hfCurrentCategory: "",
   message: "loading",
   texts: {
@@ -70,22 +73,25 @@ function reducer(state: State, action: Action): State {
         showInfoGraph: !state.showInfoGraph,
       };
 
-    case "SET_PERIOD":
+    case "AVERAGE_SUCCEEDED":
       return {
         ...state,
-        period: action.payload,
+        period: action.payload.id,
+        hfCurrentValue: action.payload.average,
+        hfCurrentCategory: action.payload.category,
       };
 
-    case "SET_HF_CURRENT":
+    case "CURRENTHF_VALUES_SUCCEEDED":
       return {
         ...state,
         hfCurrent: action.payload,
+        message: null,
       };
 
-    case "SET_MESSAGE":
+    case "CURRENTHF_VALUES_FAILED":
       return {
         ...state,
-        message: action.payload,
+        message: "no-data",
       };
 
     case "SET_TEXTS":
@@ -94,7 +100,7 @@ function reducer(state: State, action: Action): State {
         texts: { hfCurrent: action.payload },
       };
 
-    case "SET_LAYERS":
+    case "CURRENTHF_LAYERS_SUCCEEDED":
       return {
         ...state,
         layers: action.payload,
@@ -124,46 +130,57 @@ export function CurrentFootprint() {
     hfCurrent,
     hfCurrentValue,
     hfCurrentCategory,
-    message,
     texts,
     layers,
   } = state;
 
   const controller = new CurrentFootprintController();
 
-  const areaTypeId = areaType!.id;
-  const areaIdId = areaId!.id.toString();
+  if (!areaType || !areaId) {
+    context.setLoadingLayer(false);
+    return;
+  }
+
+  const areaTypeId = areaType.id;
+  const areaIdId = areaId.id;
+
+  controller.setArea(areaTypeId, areaIdId);
 
   useEffect(() => {
     setLoadingLayer(true);
-    controller.setArea(areaTypeId, areaIdId);
 
-    SearchAPI.requestMetricsValues<"currentHF">("currentHF", Number(areaIdId))
-      .then((res) => {
-        const obtainedPeriod = res?.id ?? "";
+    controller.getCurrentHFAverage().then((res) => {
+      dispatch({ type: "AVERAGE_SUCCEEDED", payload: res });
+    });
+    controller
+      .getCurrentHFValues()
+      .then((currentHFValues) => {
+        controller
+          .getCurrentHFLayers()
+          .then((layersRes) => {
+            dispatch({
+              type: "CURRENTHF_LAYERS_SUCCEEDED",
+              payload: layersRes,
+            });
+            setRasterLayers(layersRes);
+            setLoadingLayer(false);
+            setMapTitle({
+              name: `HH promedio · ${period}`,
+            });
+          })
+          .catch((e) => {
+            if (e.toString() !== "Error: request canceled") {
+              setLayerError(e.toString());
+            }
+          });
 
         dispatch({
-          type: "SET_HF_CURRENT",
-          payload: controller.transformData(res),
+          type: "CURRENTHF_VALUES_SUCCEEDED",
+          payload: currentHFValues,
         });
-
-        dispatch({
-          type: "SET_PERIOD",
-          payload: obtainedPeriod,
-        });
-
-        dispatch({
-          type: "SET_MESSAGE",
-          payload: null,
-        });
-
-        switchLayer(obtainedPeriod);
       })
       .catch(() => {
-        dispatch({
-          type: "SET_MESSAGE",
-          payload: "no-data",
-        });
+        dispatch({ type: "CURRENTHF_VALUES_FAILED" });
       });
 
     BackendAPI.requestSectionTexts("hfCurrent")
@@ -176,12 +193,7 @@ export function CurrentFootprint() {
       .catch(() => {
         dispatch({
           type: "SET_TEXTS",
-          payload: {
-            info: "",
-            cons: "",
-            meto: "",
-            quote: "",
-          },
+          payload: { info: "", cons: "", meto: "", quote: "" },
         });
       });
 
@@ -189,27 +201,6 @@ export function CurrentFootprint() {
       controller.cancelActiveRequests();
     };
   }, [areaTypeId, areaIdId]);
-
-  const switchLayer = (period: string) => {
-    setLoadingLayer(true);
-
-    controller
-      .getCurrentHFLayers(period)
-      .then((layersRes) => {
-        dispatch({ type: "SET_LAYERS", payload: layersRes });
-        setRasterLayers(layersRes);
-        setLoadingLayer(false);
-
-        setMapTitle({
-          name: `HH promedio · ${period}`,
-        });
-      })
-      .catch((e) => {
-        if (e.toString() !== "Error: request canceled") {
-          setLayerError(e.toString());
-        }
-      });
-  };
 
   const toggleInfoGraph = () => {
     dispatch({ type: "TOGGLE_INFO_GRAPH" });
@@ -246,7 +237,7 @@ export function CurrentFootprint() {
       )}
 
       <div>
-        <h6>Huella humana promedio · 2018</h6>
+        <h6>Huella humana promedio · {period}</h6>
         <h5
           style={{
             backgroundColor:
@@ -254,7 +245,7 @@ export function CurrentFootprint() {
               colorPalettes.default[0],
           }}
         >
-          {hfCurrentValue}
+          {formatNumber(hfCurrentValue, 2)}
         </h5>
       </div>
 

--- a/src/pages/search/dashboard/landscape/humanFootprint/CurrentFootprintController.ts
+++ b/src/pages/search/dashboard/landscape/humanFootprint/CurrentFootprintController.ts
@@ -1,5 +1,4 @@
 import { formatNumber } from "@utils/format";
-import BackendAPI from "pages/search/api/backendAPI";
 import { RasterLayer } from "pages/search/types/layers";
 import { matchColor } from "pages/search/utils/matchColor";
 import { CancelTokenSource } from "axios";
@@ -7,56 +6,107 @@ import { CancelTokenSource } from "axios";
 import { LargeStackedBarData } from "@composites/charts/LargeStackedBar";
 import { MetricTypesMap } from "pages/search/types/metrics";
 import SearchAPI from "pages/search/api/searchAPI";
-import { currentHFCategories } from "pages/search/types/humanFootprint";
 import { MetricsUtils } from "pages/search/utils/metrics";
+import LayerAPI from "pages/search/api/layerAPI";
 export class CurrentFootprintController {
   areaType: string = "";
-  areaId: string = "";
+  areaId: number = 0;
   activeRequests: Map<string, CancelTokenSource> = new Map();
+  classes: Set<string> = new Set();
+  itemId: string = "";
 
   constructor() {}
 
-  setArea(areaType: string, areaId: string) {
+  setArea(areaType: string, areaId: number) {
     this.areaType = areaType;
     this.areaId = areaId;
   }
 
   /**
-   * Get shape layers in GeoJSON format for current human footprint component
+   * Get the average of the current human footprint for the current area
    *
-   * @returns { Promise<ShapeLayer> } object with the parameters of the layer
+   * @returns { Promise<{ id: string; average: number, category: string }> }
    */
-  getCurrentHFLayers = async (period: string): Promise<Array<RasterLayer>> => {
+  getCurrentHFAverage() {
+    return SearchAPI.requestMetricsValues<"currentHF_average">(
+      "currentHF_average",
+      this.areaId,
+    ).then((averageValues) => {
+      // TODO: Asignar una categoría al promedi opara poder darle color, los
+      // rangos varíaron con respecto a las clasificaciones que teníamos antes
+      const category = "Baja";
+      return {
+        ...averageValues,
+        category,
+      };
+    });
+  }
+
+  /**
+   * Get the current human footprint values for the current area
+   *
+   * @returns { Promise<SmallStackedBarData[]>}
+   */
+  getCurrentHFValues() {
+    return SearchAPI.requestMetricsValues<"currentHF">(
+      "currentHF",
+      this.areaId,
+    ).then((res) => {
+      const { id, ...classes } = res;
+      this.itemId = id;
+      this.classes = new Set(
+        Object.keys(classes).filter(
+          (classId) => classes[classId as keyof typeof classes] != 0.0,
+        ),
+      );
+      return this.transformData(res);
+    });
+  }
+
+  /**
+   * Get layers for current human footprint component
+   *
+   * @returns { Promise<ShapeLayer> } layers for the classes in the current area
+   */
+  getCurrentHFLayers = async (): Promise<Array<RasterLayer>> => {
     if (this.areaId) {
       const requests: Array<Promise<{ layer: string }>> = [];
 
-      currentHFCategories.forEach((categoryId, index) => {
+      this.classes.forEach((classId) => {
         const { request, source } = SearchAPI.requestMetricsLayer(
           "currentHF",
-          period,
-          index + 1,
+          this.itemId,
+          classId,
           Number(this.areaId),
         );
         requests.push(request);
-        this.activeRequests.set(categoryId, source);
+        this.activeRequests.set(classId, source);
       });
 
       const res = await Promise.all(requests);
 
-      currentHFCategories.forEach((categoryId) => {
-        this.activeRequests.delete(categoryId);
+      this.classes.forEach((classId) => {
+        this.activeRequests.delete(classId);
       });
 
       if (res.some((result) => typeof result === "string")) {
         throw new Error("request canceled");
       }
       const layersRequests: Array<Promise<Blob>> = [];
-      res.forEach((response) => {
-        const request = SearchAPI.getLayerData(response);
+      res.forEach((layerObj) => {
+        const { request, source } = LayerAPI.getLayerData(layerObj);
         layersRequests.push(request);
+        this.activeRequests.set(layerObj.layer, source);
       });
 
       const layerResponses = await Promise.all(layersRequests);
+      res.forEach((layerObj) => {
+        this.activeRequests.delete(layerObj.layer);
+      });
+
+      if (res.some((result) => typeof result === "string")) {
+        throw new Error("request canceled");
+      }
 
       const layersBase64Promises: Array<Promise<string>> = [];
 
@@ -67,8 +117,8 @@ export class CurrentFootprintController {
 
       const layersBase64 = await Promise.all(layersBase64Promises);
 
-      return currentHFCategories.map((category, index) => ({
-        id: category,
+      return [...this.classes].map((classId, index) => ({
+        id: classId,
         data: layersBase64[index],
         selected: false,
         paneLevel: 2,
@@ -163,7 +213,7 @@ export class CurrentFootprintController {
     );
 
     /**
-     * TODO: No sé si hay una mejor forma de ordenar el objeto resultado,
+     * No sé si hay una mejor forma de ordenar el objeto resultado,
      * intenté sacar los valores directamente de las keys de MetricTypesMap["currentHF"]
      * pero el mismo interprete de typescript me los pasaba ya desordenados
      */

--- a/src/pages/search/types/api.ts
+++ b/src/pages/search/types/api.ts
@@ -10,3 +10,8 @@ export interface RasterAPIObject {
   request: Promise<{ layer: string }>;
   source: CancelTokenSource;
 }
+
+export interface BlobAPIObject {
+  request: Promise<Blob>;
+  source: CancelTokenSource;
+}

--- a/src/pages/search/types/dashboard.ts
+++ b/src/pages/search/types/dashboard.ts
@@ -11,7 +11,8 @@ export interface AreaType {
 }
 
 export interface AreaIdBasic {
-  id: string | number;
+  id: number;
+  area: number;
   name: string;
   area_type: AreaType;
 }

--- a/src/pages/search/types/ecosystems.ts
+++ b/src/pages/search/types/ecosystems.ts
@@ -1,14 +1,5 @@
-export type coverageType = "N" | "S" | "T" | "X";
-
-export type coverageLabels =
-  | ""
-  | "Natural"
-  | "Secundaria"
-  | "Transformada"
-  | "Sin clasificar / Nubes";
 export interface Coverage {
   area: number;
-  type: coverageType;
   percentage: number;
 }
 

--- a/src/pages/search/types/ecosystems.ts
+++ b/src/pages/search/types/ecosystems.ts
@@ -24,9 +24,3 @@ export interface seDetails {
   national_percentage: number;
   total_area: string;
 }
-
-export const coverageKeys: Record<string, number> = {
-  N: 1,
-  S: 2,
-  T: 3,
-} as const;

--- a/src/pages/search/types/forest.ts
+++ b/src/pages/search/types/forest.ts
@@ -1,27 +1,11 @@
 export const SCICats = ["alta", "baja_moderada"] as const;
 export const HFCats = ["estable_natural", "dinamica", "estable_alta"] as const;
 
-export const ForestLPKeys = ["perdida", "persistencia", "no_bosque"] as const;
-export const ForestLPCategories = {
-  perdida: 0,
-  persistencia: 1,
-  no_bosque: 2,
-} as const;
-
 export interface SCIHF {
   hf_pers: (typeof HFCats)[number];
   sci_cat: (typeof SCICats)[number];
   pa: string;
   area: number;
-}
-
-export interface ForestLP {
-  id: string;
-  data: Array<{
-    area: number;
-    key: (typeof ForestLPKeys)[number];
-    percentage: number;
-  }>;
 }
 
 export interface ForestLPExt {
@@ -32,30 +16,4 @@ export interface ForestLPExt {
     percentage: number;
     label: string;
   }>;
-}
-
-export interface ForestLPRawDataPolygon {
-  periodo: string;
-  perdida: number;
-  persistencia: number;
-  no_bosque: number;
-}
-
-/**
- * Loss Persistence data
- */
-export interface LPResponse {
-  period: string;
-  loss: number;
-  persistence: number;
-  noForest: number;
-}
-
-/**
- * Loss Persistence data with percents
- */
-export interface LPAreas extends LPResponse {
-  percentagesLoss: number;
-  percentagesPersistence: number;
-  percentagesNoForest: number;
 }

--- a/src/pages/search/types/forest.ts
+++ b/src/pages/search/types/forest.ts
@@ -28,7 +28,7 @@ export interface ForestLPExt {
   id: string;
   data: Array<{
     area: number;
-    key: (typeof ForestLPKeys)[number];
+    key: string;
     percentage: number;
     label: string;
   }>;

--- a/src/pages/search/types/humanFootprint.ts
+++ b/src/pages/search/types/humanFootprint.ts
@@ -1,9 +1,4 @@
-export const currentHFCategories = [
-  "natural",
-  "baja",
-  "media",
-  "alta",
-] as const;
+// TODO: Eliminar
 
 export const persistenceHFCategories = [
   "dinamica",
@@ -25,17 +20,6 @@ export const timelineHFYears = [
   "2015",
   "2018",
 ] as const;
-
-export interface currentHFValue {
-  value: number;
-  category: (typeof currentHFCategories)[number];
-}
-
-export interface currentHFCategories {
-  area: number;
-  key: (typeof currentHFCategories)[number];
-  percentage: number;
-}
 
 export interface hfPersistence {
   area: number;

--- a/src/pages/search/types/metrics.ts
+++ b/src/pages/search/types/metrics.ts
@@ -19,6 +19,7 @@ export type MetricTypesMap = {
     "id",
     "Natural" | "Baja" | "Media" | "Alta" | "Muy Alta"
   >;
+  currentHF_average: MetricDataStructure<"id", "average">;
 };
 
 export type MetricsTypes = keyof MetricTypesMap;

--- a/src/pages/search/types/metrics.ts
+++ b/src/pages/search/types/metrics.ts
@@ -13,7 +13,7 @@ export type MetricTypesMap = {
     "Natural" | "Secundaria" | "Transformada"
   >;
   lossPersistence: Array<
-    MetricDataStructure<"id", "perdida" | "persistencia" | "no_bosque">
+    MetricDataStructure<"id", "Perdida" | "Persistencia" | "No Bosque">
   >;
   currentHF: MetricDataStructure<
     "id",

--- a/src/pages/search/utils/matchColor.ts
+++ b/src/pages/search/utils/matchColor.ts
@@ -59,7 +59,6 @@ export const match = {
   },
   hfCurrent: {
     palette: "hfCurrent",
-    // TODO: This could change once the API endpoint is implemented
     sort: ["Natural", "Baja", "Media", "Alta", "Muy Alta"],
   },
   hfPersistence: {
@@ -80,7 +79,7 @@ export const match = {
   },
   forestLP: {
     palette: "forestLP",
-    sort: ["persistencia", "perdida", "ganancia", "no_bosque"],
+    sort: ["Persistencia", "Perdida", "Ganancia", "No Bosque"],
   },
   forestIntegrity: {
     palette: "forestIntegrity",

--- a/src/pages/search/utils/matchColor.ts
+++ b/src/pages/search/utils/matchColor.ts
@@ -30,7 +30,7 @@ export const match = {
   },
   coverage: {
     palette: "coverage",
-    sort: ["N", "S", "T"],
+    sort: ["Natural", "Secundaria", "Transformada"],
   },
   pa: {
     palette: "pa",

--- a/src/pages/search/utils/metrics.ts
+++ b/src/pages/search/utils/metrics.ts
@@ -18,22 +18,6 @@ export class MetricsUtils {
    * @param lpData Loss Persistence back end data
    * @returns Loss Persistence mapped data
    */
-  static mapLPResponse(
-    lpData: MetricTypesMap["lossPersistence"][number],
-  ): LPResponse {
-    return {
-      period: lpData.id,
-      loss: lpData.perdida,
-      persistence: lpData.persistencia,
-      noForest: lpData.no_bosque,
-    };
-  }
-
-  /**
-   * Map Loss Persistence object from back end
-   * @param lpData Loss Persistence back end data
-   * @returns Loss Persistence mapped data
-   */
   static mapLPForestData(lpData: ForestLPRawDataPolygon): LPResponse {
     return {
       period: lpData.periodo,
@@ -41,23 +25,6 @@ export class MetricsUtils {
       persistence: lpData.persistencia,
       noForest: lpData.no_bosque,
     };
-  }
-
-  /**
-   * Calculate Loss Persistence percentages
-   * @param lpData Loss Persistence data
-   * @returns Loss Persistence object with percentages
-   */
-  static calcLPAreas(lpData: LPResponse): LPAreas {
-    const totalHaOnePercent: number =
-      (lpData.noForest + lpData.loss + lpData.persistence) / 100;
-
-    let response = lpData as LPAreas;
-    response.percentagesLoss = lpData.loss / totalHaOnePercent;
-    response.percentagesPersistence = lpData.persistence / totalHaOnePercent;
-    response.percentagesNoForest = lpData.noForest / totalHaOnePercent;
-
-    return response;
   }
 
   /**

--- a/src/pages/search/utils/metrics.ts
+++ b/src/pages/search/utils/metrics.ts
@@ -1,32 +1,7 @@
-import {
-  ForestLPRawDataPolygon,
-  LPAreas,
-  LPResponse,
-} from "pages/search/types/forest";
-import { MetricTypesMap } from "pages/search/types/metrics";
-
 /**
  * Metrics utils
  */
 export class MetricsUtils {
-  /** **************** **/
-  /** LOSS PERSISTENCE **/
-  /** **************** **/
-
-  /**
-   * Map Loss Persistence object from back end
-   * @param lpData Loss Persistence back end data
-   * @returns Loss Persistence mapped data
-   */
-  static mapLPForestData(lpData: ForestLPRawDataPolygon): LPResponse {
-    return {
-      period: lpData.periodo,
-      loss: lpData.perdida,
-      persistence: lpData.persistencia,
-      noForest: lpData.no_bosque,
-    };
-  }
-
   /**
    * Convert blob object to Base64 string
    * @param blob Blob data


### PR DESCRIPTION
## 🛠️ Changes
- Update connections to the backend for values and layers for the following metrics: `lossPersistence`, `coverage`, `currentHF`, `currentHF_average`
- Fix missing attribute to show polygon area in dashboard
- Fix LossPersistence graph (Y axis was missing T-T)

## 📝 Associated issues
Solves LIB-439

## 🤔 Considerations
* There are broken parts on ecosystems box and requests. Should be fixed in another issue since is a lot of work to be added to this one
* The class for the current average human footprint is hardcoded, it's necessary to set the color of the box, we need to decide if is something to be added to the  `currentHF_average` metric in the backend or just calculate the ranges here in the frontend

## ✅ Checks
* Remember to test with the drawn polygon too, it worked for me and it felt awesome.

