### PR TITLE
Crea el componente de busqueda y selección dinámica de respuestas en odata

### DIFF
--- a/src/core/ui/ComboBox.tsx
+++ b/src/core/ui/ComboBox.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Check, ChevronsUpDown } from "lucide-react";
+import { Check, ChevronsUpDown, type LucideIcon } from "lucide-react";
 
 import { cn } from "@ui/shadCN/lib/utils";
 import { Button } from "@ui/shadCN/component/button";
@@ -23,9 +23,11 @@ type ComboBoxProps<T> = {
   maxItems?: number;
   value: number | string;
   setValue: React.Dispatch<React.SetStateAction<string>>;
+  onSearchChange?: (value: string) => void;
   disabled?: boolean;
   uiText: { itemNotFound: string; trigger: string; inputPlaceholder: string };
   className?: string;
+  icon?: LucideIcon;
 } & (
   | { keys: { forLabel?: keyof T; forValue: keyof T } }
   | { keys: { forLabel: keyof T; forValue?: keyof T } }
@@ -37,10 +39,12 @@ export function Combobox<T>({
   maxItems,
   value,
   setValue,
+  onSearchChange,
   keys,
   uiText,
   disabled = false,
   className = "",
+  icon,
 }: ComboBoxProps<T>) {
   const [open, setOpen] = React.useState(false);
 
@@ -48,6 +52,8 @@ export function Combobox<T>({
   const itemLabel = (keys?.forLabel ?? keys.forValue) as keyof T;
 
   const componentWidth = "w-full";
+
+  const Icon = icon || ChevronsUpDown;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -68,19 +74,25 @@ export function Combobox<T>({
               )
             : uiText.trigger}
 
-          <ChevronsUpDown className="text-primary" />
+          <Icon className="text-primary" />
         </Button>
       </PopoverTrigger>
 
       <PopoverContent className="p-0 w-(--radix-popover-trigger-width)">
         <Command>
-          <CommandInput placeholder={uiText.inputPlaceholder} className="h-9" />
+          <CommandInput
+            onValueChange={onSearchChange}
+            placeholder={uiText.inputPlaceholder}
+            className="h-9"
+          />
 
           <CommandList
             className={cn(!maxItems ? "overflow-y-auto max-h-[300px]" : "")}
-            style={maxItems ? { maxHeight: `${33 * maxItems}px` } : undefined}
+            style={maxItems ? { maxHeight: `${45 * maxItems}px` } : undefined}
           >
-            <CommandEmpty>{uiText.itemNotFound}</CommandEmpty>
+            {uiText.itemNotFound !== "" && (
+              <CommandEmpty>{uiText.itemNotFound}</CommandEmpty>
+            )}
             <CommandGroup>
               {items.map((item) => {
                 const itemValueStr = String(item[itemValue]);

--- a/src/core/ui/ComboBox.tsx
+++ b/src/core/ui/ComboBox.tsx
@@ -90,9 +90,7 @@ export function Combobox<T>({
             className={cn(!maxItems ? "overflow-y-auto max-h-[300px]" : "")}
             style={maxItems ? { maxHeight: `${45 * maxItems}px` } : undefined}
           >
-            {uiText.itemNotFound !== "" && (
-              <CommandEmpty>{uiText.itemNotFound}</CommandEmpty>
-            )}
+            <CommandEmpty>{uiText.itemNotFound}</CommandEmpty>
             <CommandGroup>
               {items.map((item) => {
                 const itemValueStr = String(item[itemValue]);

--- a/src/core/ui/ComboboxOData.tsx
+++ b/src/core/ui/ComboboxOData.tsx
@@ -10,7 +10,7 @@ import { Ellipsis, Search } from "lucide-react";
 type ComboboxODataProps<T> = {
   id?: string;
   endpoint: string;
-  value: number | string;
+  value: number;
   setValue: React.Dispatch<React.SetStateAction<string>>;
   sources: (keyof T)[];
   oDataEntity?: string;
@@ -40,7 +40,7 @@ type ComboboxODataProps<T> = {
  * @param endpoint - The API path for the OData service.
  * @param sources - Entity fields used to build the `contains` filter logic.
  * @param oDataEntity - Optional collection name for nested `any()` lambda queries.
- * @param loadOnEmpty - Optional, if true load load the items returned by the endpoint with no filter, it defaults to false.
+ * @param loadOnEmpty - Optional, if true load the items returned by the endpoint with no filter, it defaults to true.
  * @param sourceProcess - Callback to transform OData items into `{ value, label }` format.
  * @param fixedSearchParams - Static parameters (like $expand) merged into every request.
  * @param maxItems - The $top limit for API results.

--- a/src/core/ui/ComboboxOData.tsx
+++ b/src/core/ui/ComboboxOData.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useRef, useState } from "react";
+import type { ODataParams, ODataResponse } from "@appTypes/odata";
+import { debouncer } from "@utils/debouncer";
+import { Combobox } from "@ui/ComboBox";
+import { monitoringAPI } from "pages/monitoring/api/core";
+import { isMonitoringAPIError } from "pages/monitoring/api/types/guards";
+import { ErrorsList } from "@ui/LabelingWithErrors";
+import { Ellipsis, Search } from "lucide-react";
+
+type ComboboxODataProps<T> = {
+  id?: string;
+  endpoint: string;
+  value: number | string;
+  setValue: React.Dispatch<React.SetStateAction<string>>;
+  sources: (keyof T)[];
+  oDataEntity?: string;
+  sourceProcess: (oDataResponse: T[]) => { value: string; label: string }[];
+  fixedSearchParams?: ODataParams;
+  maxItems: number; // items de top
+  disabled?: boolean;
+  uiText: {
+    itemNotFound: string;
+    trigger: string;
+    inputPlaceholder: string;
+  };
+  className?: string;
+};
+
+/**
+ * A specialized Combobox wrapper that performs debounced server-side searching
+ * against OData-compliant endpoints.
+ *
+ * @template T - The expected entity type from the OData service.
+ *
+ * @param id - Unique identifier for the DOM element.
+ * @param value - The currently selected key/ID.
+ * @param setValue - State dispatcher to update the selection.
+ * @param endpoint - The API path for the OData service.
+ * @param sources - Entity fields used to build the `contains` filter logic.
+ * @param oDataEntity - Optional collection name for nested `any()` lambda queries.
+ * @param sourceProcess - Callback to transform OData items into `{ value, label }` format.
+ * @param fixedSearchParams - Static parameters (like $expand) merged into every request.
+ * @param maxItems - The $top limit for API results.
+ * @param disabled - Disables user interaction and visual state.
+ * @param uiText - I18n object for not found messages, trigger labels, and placeholders.
+ * @param className - Custom CSS classes for the container.
+ *
+ * * @remarks
+ * - **Search Logic**: Automatically constructs complex OData `contains` filters
+ * using the provided `sources`.
+ * - **Debouncing**: Execution is delayed by 500ms to optimize API usage.
+ * - **Conditional Fetching**: No requests are made if the search input is empty.
+ * - **Error Handling**: Integrates with `monitoringAPI` to display service errors.
+ */
+export function ComboboxOData<T>({
+  id,
+  value,
+  setValue,
+  endpoint,
+  sources,
+  oDataEntity,
+  sourceProcess,
+  fixedSearchParams,
+  maxItems,
+  disabled,
+  uiText,
+  className,
+}: ComboboxODataProps<T>) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [errors, setErrors] = useState<string[]>([]);
+  const [items, setItems] = useState<{ value: string; label: string }[]>([]);
+  const [searchParams, setSearchParams] = useState<ODataParams>(
+    fixedSearchParams ?? {},
+  );
+
+  const makeODataSearchString = (searchValue: string) => {
+    if (searchValue === "") {
+      return "";
+    }
+
+    const alias = "l";
+    const prefix = oDataEntity ? `${alias}/` : "";
+    const filterStrings: string[] = [];
+
+    for (const source of sources) {
+      const normalizaedSource = `tolower(${prefix}${source as string})`;
+      const base = `contains(${normalizaedSource}, '${searchValue.toLowerCase()}')`;
+      filterStrings.push(base);
+    }
+
+    return prefix
+      ? `${oDataEntity}/any(${alias}: ${filterStrings.join(" or ")})`
+      : filterStrings.join(" or ");
+  };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!searchParams.filter) {
+        setItems([]);
+        return;
+      }
+
+      setIsLoading(true);
+      setErrors([]);
+
+      const res = await monitoringAPI<ODataResponse<T>>({
+        type: "get",
+        endpoint: endpoint,
+        options: { oData: searchParams },
+      });
+
+      if (isMonitoringAPIError(res)) {
+        setErrors(res.data.map((err) => err.msg));
+        setIsLoading(false);
+        setItems([]);
+        return;
+      }
+
+      setIsLoading(false);
+      setItems(sourceProcess(res.value));
+    };
+
+    void fetchData();
+  }, [endpoint, searchParams, sourceProcess]);
+
+  const handleSearch = useRef(
+    debouncer((searchString: string) => {
+      if (searchString.trim() === "") {
+        setItems([]);
+        setSearchParams((prev) => {
+          const { filter: _, ...rest } = prev;
+          return rest;
+        });
+        return;
+      }
+      setSearchParams((oldParams) => ({
+        ...oldParams,
+        top: maxItems,
+        filter: makeODataSearchString(searchString),
+      }));
+    }, 0.5),
+  ).current;
+
+  return (
+    <>
+      <ErrorsList errorItems={errors} />
+      <Combobox
+        id={id}
+        items={items}
+        value={value}
+        setValue={setValue}
+        maxItems={maxItems}
+        onSearchChange={handleSearch}
+        keys={{ forValue: "value", forLabel: "label" }}
+        uiText={{
+          itemNotFound: !searchParams.filter ? "" : uiText.itemNotFound,
+          trigger: uiText.trigger,
+          inputPlaceholder: uiText.inputPlaceholder,
+        }}
+        disabled={disabled || isLoading}
+        className={className}
+        icon={isLoading ? Ellipsis : Search}
+      />
+    </>
+  );
+}

--- a/src/core/ui/ComboboxOData.tsx
+++ b/src/core/ui/ComboboxOData.tsx
@@ -23,6 +23,7 @@ type ComboboxODataProps<T> = {
     itemNotFound: string;
     trigger: string;
     inputPlaceholder: string;
+    onEmptySearch?: string;
   };
   className?: string;
 };
@@ -61,7 +62,7 @@ export function ComboboxOData<T>({
   endpoint,
   sources,
   oDataEntity,
-  loadOnEmpty = false,
+  loadOnEmpty = true,
   sourceProcess,
   fixedSearchParams,
   maxItems,
@@ -100,7 +101,7 @@ export function ComboboxOData<T>({
 
   useEffect(() => {
     const fetchData = async () => {
-      if (loadOnEmpty && !searchParams.filter) {
+      if (!loadOnEmpty && !searchParams.filter) {
         setItems([]);
         return;
       }
@@ -131,7 +132,7 @@ export function ComboboxOData<T>({
 
   const handleSearch = useRef(
     debouncer((searchString: string) => {
-      if (loadOnEmpty && searchString.trim() === "") {
+      if (!loadOnEmpty && searchString.trim() === "") {
         setItems([]);
         setSearchParams((prev) => {
           const { filter: _, ...rest } = prev;
@@ -163,7 +164,10 @@ export function ComboboxOData<T>({
         }}
         keys={{ forValue: "value", forLabel: "label" }}
         uiText={{
-          itemNotFound: !searchParams.filter ? "" : uiText.itemNotFound,
+          itemNotFound:
+            !loadOnEmpty && !searchParams.filter
+              ? (uiText?.onEmptySearch ?? "")
+              : uiText.itemNotFound,
           trigger: uiText.trigger,
           inputPlaceholder: uiText.inputPlaceholder,
         }}

--- a/src/core/ui/ComboboxOData.tsx
+++ b/src/core/ui/ComboboxOData.tsx
@@ -10,7 +10,7 @@ import { Ellipsis, Search } from "lucide-react";
 type ComboboxODataProps<T> = {
   id?: string;
   endpoint: string;
-  value: number;
+  value: string;
   setValue: React.Dispatch<React.SetStateAction<string>>;
   sources: (keyof T)[];
   oDataEntity?: string;

--- a/src/core/ui/ComboboxOData.tsx
+++ b/src/core/ui/ComboboxOData.tsx
@@ -14,6 +14,7 @@ type ComboboxODataProps<T> = {
   setValue: React.Dispatch<React.SetStateAction<string>>;
   sources: (keyof T)[];
   oDataEntity?: string;
+  loadOnEmpty?: boolean;
   sourceProcess: (oDataResponse: T[]) => { value: string; label: string }[];
   fixedSearchParams?: ODataParams;
   maxItems: number; // items de top
@@ -38,6 +39,7 @@ type ComboboxODataProps<T> = {
  * @param endpoint - The API path for the OData service.
  * @param sources - Entity fields used to build the `contains` filter logic.
  * @param oDataEntity - Optional collection name for nested `any()` lambda queries.
+ * @param loadOnEmpty - Optional, if true load load the items returned by the endpoint with no filter, it defaults to false.
  * @param sourceProcess - Callback to transform OData items into `{ value, label }` format.
  * @param fixedSearchParams - Static parameters (like $expand) merged into every request.
  * @param maxItems - The $top limit for API results.
@@ -59,6 +61,7 @@ export function ComboboxOData<T>({
   endpoint,
   sources,
   oDataEntity,
+  loadOnEmpty = false,
   sourceProcess,
   fixedSearchParams,
   maxItems,
@@ -69,9 +72,11 @@ export function ComboboxOData<T>({
   const [isLoading, setIsLoading] = useState(false);
   const [errors, setErrors] = useState<string[]>([]);
   const [items, setItems] = useState<{ value: string; label: string }[]>([]);
-  const [searchParams, setSearchParams] = useState<ODataParams>(
-    fixedSearchParams ?? {},
-  );
+  const [writing, setWriting] = useState(false);
+  const [searchParams, setSearchParams] = useState<ODataParams>({
+    ...(fixedSearchParams ?? {}),
+    top: maxItems,
+  });
 
   const makeODataSearchString = (searchValue: string) => {
     if (searchValue === "") {
@@ -95,7 +100,7 @@ export function ComboboxOData<T>({
 
   useEffect(() => {
     const fetchData = async () => {
-      if (!searchParams.filter) {
+      if (loadOnEmpty && !searchParams.filter) {
         setItems([]);
         return;
       }
@@ -109,6 +114,7 @@ export function ComboboxOData<T>({
         options: { oData: searchParams },
       });
 
+      setWriting(false);
       if (isMonitoringAPIError(res)) {
         setErrors(res.data.map((err) => err.msg));
         setIsLoading(false);
@@ -121,11 +127,11 @@ export function ComboboxOData<T>({
     };
 
     void fetchData();
-  }, [endpoint, searchParams, sourceProcess]);
+  }, [endpoint, loadOnEmpty, searchParams, sourceProcess]);
 
   const handleSearch = useRef(
     debouncer((searchString: string) => {
-      if (searchString.trim() === "") {
+      if (loadOnEmpty && searchString.trim() === "") {
         setItems([]);
         setSearchParams((prev) => {
           const { filter: _, ...rest } = prev;
@@ -133,6 +139,7 @@ export function ComboboxOData<T>({
         });
         return;
       }
+
       setSearchParams((oldParams) => ({
         ...oldParams,
         top: maxItems,
@@ -150,7 +157,10 @@ export function ComboboxOData<T>({
         value={value}
         setValue={setValue}
         maxItems={maxItems}
-        onSearchChange={handleSearch}
+        onSearchChange={(w) => {
+          setWriting(true);
+          handleSearch(w);
+        }}
         keys={{ forValue: "value", forLabel: "label" }}
         uiText={{
           itemNotFound: !searchParams.filter ? "" : uiText.itemNotFound,
@@ -159,7 +169,7 @@ export function ComboboxOData<T>({
         }}
         disabled={disabled || isLoading}
         className={className}
-        icon={isLoading ? Ellipsis : Search}
+        icon={writing ? Ellipsis : Search}
       />
     </>
   );

--- a/src/pages/monitoring/api/types/guards.ts
+++ b/src/pages/monitoring/api/types/guards.ts
@@ -15,7 +15,10 @@ export function isMonitoringAPIError(
   return (
     typeof response === "object" &&
     response !== null &&
+    !("then" in response) &&
     "status" in response &&
-    "message" in response
+    "message" in response &&
+    "data" in response &&
+    Array.isArray(response.data)
   );
 }

--- a/src/pages/monitoring/outlets/initiativesMap/Browser.tsx
+++ b/src/pages/monitoring/outlets/initiativesMap/Browser.tsx
@@ -15,7 +15,6 @@ import { JoinInitiativeRequestButton } from "pages/monitoring/ui/JoinInitiativeR
 
 import { useInitiativeCTX } from "pages/monitoring/hooks/useInitiativeCTX";
 import { ComboboxOData } from "@ui/ComboboxOData";
-import { InitiativeFullInfo } from "pages/monitoring/types/initiative";
 
 export function Browser() {
   // NOTE: Esto es para poder probar el botón de solicitud de ingreso,
@@ -28,7 +27,6 @@ export function Browser() {
   const [value, setValue] = useState<string>("");
   const [value2, setValue2] = useState<string>("");
 
-  console.log(value);
   useEffect(() => {
     const fetchInitiatives = async () => {
       const initiatives = await getInitiatives({ orderby: "id desc" });

--- a/src/pages/monitoring/outlets/initiativesMap/Browser.tsx
+++ b/src/pages/monitoring/outlets/initiativesMap/Browser.tsx
@@ -2,7 +2,11 @@ import { type ChangeEvent, useEffect, useState } from "react";
 
 import { getInitiatives } from "pages/monitoring/api/services/initiatives";
 import { isMonitoringAPIError } from "pages/monitoring/api/types/guards";
-import type { ODataInitiative } from "pages/monitoring/types/odataResponse";
+import type {
+  ODataInitiative,
+  ODataInitiativeShortEntry,
+  ODataTag,
+} from "pages/monitoring/types/odataResponse";
 import {
   NativeSelect,
   NativeSelectOption,
@@ -10,6 +14,8 @@ import {
 import { JoinInitiativeRequestButton } from "pages/monitoring/ui/JoinInitiativeRequestButton";
 
 import { useInitiativeCTX } from "pages/monitoring/hooks/useInitiativeCTX";
+import { ComboboxOData } from "@ui/ComboboxOData";
+import { InitiativeFullInfo } from "pages/monitoring/types/initiative";
 
 export function Browser() {
   // NOTE: Esto es para poder probar el botón de solicitud de ingreso,
@@ -19,7 +25,10 @@ export function Browser() {
     ODataInitiative["value"]
   >([]);
   const { setInitiative } = useInitiativeCTX();
+  const [value, setValue] = useState<string>("");
+  const [value2, setValue2] = useState<string>("");
 
+  console.log(value);
   useEffect(() => {
     const fetchInitiatives = async () => {
       const initiatives = await getInitiatives({ orderby: "id desc" });
@@ -53,6 +62,46 @@ export function Browser() {
       </NativeSelect>
 
       <JoinInitiativeRequestButton />
+
+      <ComboboxOData<ODataInitiativeShortEntry>
+        value={value}
+        setValue={setValue}
+        endpoint="Initiative"
+        sources={["name"]}
+        sourceProcess={(odataResponse) =>
+          odataResponse.map((item) => ({
+            value: String(item.id),
+            label: item.name,
+          }))
+        }
+        fixedSearchParams={{ orderby: "name asc" }}
+        maxItems={4}
+        uiText={{
+          itemNotFound: "no se encuentra la iniciativa",
+          trigger: "Buscar iniciativa",
+          inputPlaceholder: "Escribe el nombre de la iniciativa",
+        }}
+      />
+
+      <ComboboxOData<ODataTag>
+        value={value2}
+        setValue={setValue2}
+        endpoint="Tag"
+        sources={["name"]}
+        sourceProcess={(odataResponse) =>
+          odataResponse.map((item) => ({
+            value: String(item.id),
+            label: item.name,
+          }))
+        }
+        fixedSearchParams={{ orderby: "name asc" }}
+        maxItems={4}
+        uiText={{
+          itemNotFound: "no se encuentra el tag",
+          trigger: "Buscar tag",
+          inputPlaceholder: "Escribe el nombre del tag",
+        }}
+      />
     </div>
   );
 }

--- a/src/pages/monitoring/outlets/initiativesMap/Browser.tsx
+++ b/src/pages/monitoring/outlets/initiativesMap/Browser.tsx
@@ -76,7 +76,7 @@ export function Browser() {
         fixedSearchParams={{ orderby: "name asc" }}
         maxItems={4}
         uiText={{
-          itemNotFound: "no se encuentra la iniciativa",
+          itemNotFound: "No se encuentra la iniciativa",
           trigger: "Buscar iniciativa",
           inputPlaceholder: "Escribe el nombre de la iniciativa",
           onEmptySearch: "Escribe para iniciar la búsqueda",
@@ -98,7 +98,7 @@ export function Browser() {
         fixedSearchParams={{ orderby: "name asc" }}
         maxItems={4}
         uiText={{
-          itemNotFound: "no se encuentra el tag",
+          itemNotFound: "No se encuentra el tag",
           trigger: "Buscar tag",
           inputPlaceholder: "Escribe el nombre del tag",
         }}

--- a/src/pages/monitoring/outlets/initiativesMap/Browser.tsx
+++ b/src/pages/monitoring/outlets/initiativesMap/Browser.tsx
@@ -72,12 +72,14 @@ export function Browser() {
             label: item.name,
           }))
         }
+        loadOnEmpty={false}
         fixedSearchParams={{ orderby: "name asc" }}
         maxItems={4}
         uiText={{
           itemNotFound: "no se encuentra la iniciativa",
           trigger: "Buscar iniciativa",
           inputPlaceholder: "Escribe el nombre de la iniciativa",
+          onEmptySearch: "Escribe para iniciar la búsqueda",
         }}
       />
 
@@ -92,6 +94,7 @@ export function Browser() {
             label: item.name,
           }))
         }
+        loadOnEmpty={true}
         fixedSearchParams={{ orderby: "name asc" }}
         maxItems={4}
         uiText={{

--- a/src/pages/monitoring/types/odataResponse.ts
+++ b/src/pages/monitoring/types/odataResponse.ts
@@ -107,6 +107,16 @@ export type UserInInitiative = {
   users: InitiativeUser[];
 };
 
+interface TagCategory extends HasId {
+  name: string;
+}
+
+export interface ODataTag extends HasId {
+  name: string;
+  url?: string;
+  category: TagCategory;
+}
+
 export type ODataLog = ODataResponse<ODataLogEntryShort>;
 export type ODataInitiative = ODataResponse<ODataInitiativeShortEntry>;
 export type ODataUserRequest = ODataResponse<ODataInitiativeUserRequest>;


### PR DESCRIPTION
## 🛠️ Changes
Este jue cortito... el demo lo monté dentro del mapa de iniciativas, mientras tengo que hacer el componente de tags que lo necesita

Al principio lo iba a trabajar sobre un NativeSelect, pero me pareció más apropiado por ui and shit el combobox... por lo que creé el componente ComboboxOData, que es un wrapper que gestiona búsquedas asíncronas mediante OData. Este componente construye dinámicamente consultas de tipo `contains` basadas en un arreglo de propiedades definidas en `sources` y soporta búsquedas en colecciones anidadas a través del operador `any()` si se especifica una `oDataEntity`. Para no hacernos ddosing y manejar mas calmadamente el consumo de la API, puse debounce de 500ms y una lógica de control que bloquea las peticiones y limpia la lista de resultados cuando la cadena de búsqueda está vacía, también hay un proceso de normalizacion de la respuesta para que entre dentro del combobox usando `sourceProcess`.

como fue breve, aproveché para hacer un pelín más robuisto el typeguard de isMonitoringAPIError pues creo que lo que se lo saltó cuando Erica estaba montando la presentación fue una condición de carrera entre la carga del elemento de la barra de busqueda y la poblada de locaciones al iniciar la app

## 📝 Associated issues

resolves [LIB-565](https://linear.app/biodev/issue/LIB-565/componente-de-seleccion-dinamica-frontend)

## 🤔 Considerations

* aunque es fácil implementar el `sourceProcess` desde la misma definicion del componente, en cosas mas cargadas puede ser necesario un `useCallback` para evitar ciclos de renderizado raritos e innecesarios en el `useEffect` que maneja el fetch.
* Para tener control sobre la cadena de búsqueda, tuve que agregarle al combobox el parámetro opcional `onSearchChange`... u le metía también un ícono opcional :P