### PR TITLE
Add current connectivity section

### DIFF
--- a/src/core/composites/charts/SmallBars.tsx
+++ b/src/core/composites/charts/SmallBars.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ResponsiveBar } from "@nivo/bar";
 import { type AxisTickProps } from "@nivo/axes";
 
@@ -52,6 +52,7 @@ interface SmallBarsProps {
   axisX?: AxisX;
   gridXValues?: number;
   alternateAxisY?: AlternateAxisY;
+  animate?: boolean;
 }
 
 export interface SmallBarsDataDetails {
@@ -82,6 +83,7 @@ export function SmallBarsElement({
   margin = { top: 20, right: 15, bottom: 0, left: 90 },
   axisY = { enabled: false, legend: "" },
   axisX = { enabled: false, legend: "", format: ".2f", tickValues: undefined },
+  animate = true,
 }: SmallBarsProps) {
   const [selectedIndexValue, setSelectedIndexValue] =
     useState<SmallBarsState>(SIVInput);
@@ -99,10 +101,16 @@ export function SmallBarsElement({
     return transformedData;
   };
 
+  const transformedData = useMemo(() => transformData(data), [data]);
+
+  useEffect(() => {
+    setSelectedIndexValue(SIVInput);
+  }, [SIVInput, data, keys]);
+
   return (
     <div style={{ height }}>
       <ResponsiveBar
-        data={transformData(data)}
+        data={transformedData}
         keys={keys}
         indexBy="group"
         layout="horizontal"
@@ -165,7 +173,7 @@ export function SmallBarsElement({
           }
           return colors(String(id));
         }}
-        animate
+        animate={animate}
         theme={{
           axis: {
             legend: { text: { fontSize: "14" } },

--- a/src/pages/search/dashboard/Landscape.tsx
+++ b/src/pages/search/dashboard/Landscape.tsx
@@ -109,7 +109,7 @@ class Landscape extends React.Component<Props, State> {
           openTab: childMap.forest,
         },
       },
-      /*{
+      {
         label: {
           id: "connectivity",
           name: "Conectividad de Áreas Protegidas",
@@ -119,7 +119,7 @@ class Landscape extends React.Component<Props, State> {
           handleAccordionChange: this.handleAccordionChange,
           openTab: childMap.connectivity,
         },
-      },*/
+      },
     ];
 
     let selected: Array<string> = [];

--- a/src/pages/search/dashboard/landscape/PAConnectivity.tsx
+++ b/src/pages/search/dashboard/landscape/PAConnectivity.tsx
@@ -16,7 +16,7 @@ const PAConnectivity: React.FC<componentProps> = (props) => {
       },
       component: CurrentPAConnectivity,
     },
-    {
+    /*{
       label: {
         id: "timelinePAConn",
         name: "Histórico",
@@ -31,7 +31,7 @@ const PAConnectivity: React.FC<componentProps> = (props) => {
         collapsed: openTab !== "currentSEPAConn",
       },
       component: CurrentSEPAConnectivity,
-    },
+    },*/
   ];
   return (
     <div style={{ width: "100%" }}>

--- a/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivity.tsx
+++ b/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivity.tsx
@@ -5,10 +5,8 @@ import { PointFilledLegend } from "@ui/CssLegends";
 import { ShortInfo } from "@composites/ShortInfo";
 import { IconTooltip } from "@ui/Tooltips";
 import { Button } from "@ui/shadCN/component/button";
-import {
-  SearchLegacyCTX,
-  type LegacyContextValues,
-} from "pages/search/hooks/SearchContext";
+import { useSearchLegacyCTX } from "pages/search/hooks/SearchContext";
+
 import BackendAPI from "pages/search/api/backendAPI";
 import { matchColor } from "pages/search/utils/matchColor";
 import TextBoxes from "@ui/TextBoxes";
@@ -121,8 +119,7 @@ function reducer(
 }
 
 function CurrentPAConnectivity(_: Props) {
-  const context = useContext(SearchLegacyCTX) as LegacyContextValues;
-  const { areaType, areaId } = context;
+  const { areaType, areaId } = useSearchLegacyCTX();
 
   const controllerRef = useRef(new CurrentPAConnectivityController());
   const controller = controllerRef.current;
@@ -200,9 +197,8 @@ function CurrentPAConnectivity(_: Props) {
         <div className="mb2 ml-6">
           <Button
             type="button"
-            variant="default"
+            variant="outline"
             size="sm"
-            className="border border-amber-700/30 bg-amber-500 text-amber-950 shadow-sm transition-colors hover:bg-amber-400"
             onClick={toggleDpcMode}
           >
             {showLowestDpc ? "Áreas con mayor dPC" : "Áreas con menor dPC"}

--- a/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivity.tsx
+++ b/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivity.tsx
@@ -247,7 +247,6 @@ function CurrentPAConnectivity(_: Props) {
                 matchColor("coverage")(key) || colorPalettes.default[0]
               }
               onClickHandler={() => {}}
-              animate={false}
               margin={{
                 bottom: 50,
                 left: 40,

--- a/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivity.tsx
+++ b/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivity.tsx
@@ -22,6 +22,7 @@ import {
 } from "@composites/charts/SmallBars";
 import { type MessageWrapperType } from "@composites/charts/withMessageWrapper";
 import { CurrentPAConnectivityController } from "pages/search/dashboard/landscape/connectivity/CurrentPAConnectivityController";
+import colorPalettes from "pages/search/utils/colorPalettes";
 
 const legendDPCCategories = {
   muy_bajo: "Muy bajo",
@@ -198,27 +199,33 @@ function CurrentPAConnectivity(_: Props) {
     <div className="graphcontainer pt6">
       <div>
         <h6>Aporte de las áreas protegidas a la conectividad</h6>
-        <div className="mb2 flex flex-wrap items-center gap-2">
+        <IconTooltip title="Interpretación">
+          <span className="iconWrapper">
+            <InfoIcon
+              fontSize="medium"
+              className={`metrics-info-icon${infoShown.has("dpc") ? " activeBox" : ""}`}
+              onClick={() => toggleInfo("dpc")}
+            />
+          </span>
+        </IconTooltip>
+        <div className="mb2 ml-6">
           <Button
             type="button"
-            variant="outline"
+            variant="default"
             size="sm"
+            className="border border-amber-700/30 bg-amber-500 text-amber-950 shadow-sm transition-colors hover:bg-amber-400"
             onClick={toggleDpcMode}
           >
             {showLowestDpc ? "Áreas con mayor dPC" : "Áreas con menor dPC"}
           </Button>
+        </div>
+        <div className="mb2 ml-6">
           <span className="text-sm text-muted-foreground">
             {showLowestDpc
               ? "Áreas que menos aportan."
               : "Áreas que más aportan."}
           </span>
         </div>
-        <IconTooltip title="Interpretación">
-          <InfoIcon
-            className={`downSpecial${infoShown.has("dpc") ? " activeBox" : ""}`}
-            onClick={() => toggleInfo("dpc")}
-          />
-        </IconTooltip>
         {infoShown.has("dpc") && (
           <ShortInfo
             description={`<p>${texts.paConnDPC.info}</p>`}
@@ -236,7 +243,9 @@ function CurrentPAConnectivity(_: Props) {
               keys={graphData.keys}
               tooltips={graphData.tooltips}
               loadStatus={messages.dpc}
-              colors={matchColor("dpc")}
+              colors={(key: string) =>
+                matchColor("coverage")(key) || colorPalettes.default[0]
+              }
               onClickHandler={() => {}}
               animate={false}
               margin={{

--- a/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivity.tsx
+++ b/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivity.tsx
@@ -125,26 +125,20 @@ function CurrentPAConnectivity(_: Props) {
   const { areaType, areaId } = context;
 
   const controllerRef = useRef(new CurrentPAConnectivityController());
-  const mountedRef = useRef(false);
-  const dpcRequestIdRef = useRef(0);
+  const controller = controllerRef.current;
 
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const loadDpcData = (showLowestDpc: boolean) => {
     dispatch({ type: "SET_SHOW_LOWEST", payload: showLowestDpc });
 
-    const requestId = ++dpcRequestIdRef.current;
-
-    controllerRef.current
+    controller
       .getDpcData(showLowestDpc)
       .then((result) => {
-        if (!mountedRef.current || requestId !== dpcRequestIdRef.current)
-          return;
         dispatch({ type: "DPC_SUCCEEDED", payload: result });
       })
-      .catch(() => {
-        if (!mountedRef.current || requestId !== dpcRequestIdRef.current)
-          return;
+      .catch((error) => {
+        if (error?.message === "request canceled") return;
         dispatch({ type: "DPC_FAILED" });
       });
   };
@@ -154,22 +148,18 @@ function CurrentPAConnectivity(_: Props) {
       return;
     }
 
-    mountedRef.current = true;
     const areaTypeId = areaType.id;
     const areaIdId = areaId.id.toString();
 
-    controllerRef.current.setArea(areaTypeId, areaIdId);
-    dpcRequestIdRef.current += 1;
+    controller.setArea(areaTypeId, areaIdId);
 
     loadDpcData(false);
 
     BackendAPI.requestSectionTexts("paConnDPC")
       .then((res) => {
-        if (!mountedRef.current) return;
         dispatch({ type: "SET_TEXTS", payload: res });
       })
       .catch(() => {
-        if (!mountedRef.current) return;
         dispatch({
           type: "SET_TEXTS",
           payload: { info: "", cons: "", meto: "", quote: "" },
@@ -177,7 +167,6 @@ function CurrentPAConnectivity(_: Props) {
       });
 
     return () => {
-      mountedRef.current = false;
       controllerRef.current.cancelActiveRequests();
     };
   }, [areaType, areaId]);

--- a/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivity.tsx
+++ b/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivity.tsx
@@ -22,7 +22,6 @@ import {
 } from "@composites/charts/SmallBars";
 import { type MessageWrapperType } from "@composites/charts/withMessageWrapper";
 import { CurrentPAConnectivityController } from "pages/search/dashboard/landscape/connectivity/CurrentPAConnectivityController";
-import { ShapeLayer } from "pages/search/types/layers";
 
 const legendDPCCategories = {
   muy_bajo: "Muy bajo",
@@ -49,7 +48,6 @@ interface CurrentPAConnState {
   texts: {
     paConnDPC: textsObject;
   };
-  layers: Array<ShapeLayer>;
 }
 
 type DpcPayload = {
@@ -66,8 +64,7 @@ type Action =
   | { type: "SET_SHOW_LOWEST"; payload: boolean }
   | { type: "DPC_SUCCEEDED"; payload: DpcPayload }
   | { type: "DPC_FAILED" }
-  | { type: "SET_TEXTS"; payload: textsObject }
-  | { type: "SET_LAYERS"; payload: Array<ShapeLayer> };
+  | { type: "SET_TEXTS"; payload: textsObject };
 
 const initialState: CurrentPAConnState = {
   infoShown: new Set(["dpc"]),
@@ -84,7 +81,6 @@ const initialState: CurrentPAConnState = {
   texts: {
     paConnDPC: { info: "", cons: "", meto: "", quote: "" },
   },
-  layers: [],
 };
 
 function reducer(
@@ -118,8 +114,6 @@ function reducer(
       };
     case "SET_TEXTS":
       return { ...state, texts: { paConnDPC: action.payload } };
-    case "SET_LAYERS":
-      return { ...state, layers: action.payload };
     default:
       return state;
   }
@@ -127,15 +121,7 @@ function reducer(
 
 function CurrentPAConnectivity(_: Props) {
   const context = useContext(SearchLegacyCTX) as LegacyContextValues;
-  const {
-    areaType,
-    areaId,
-    setShapeLayers,
-    setLoadingLayer,
-    setLayerError,
-    setMapTitle,
-    setShowAreaLayer,
-  } = context;
+  const { areaType, areaId } = context;
 
   const controllerRef = useRef(new CurrentPAConnectivityController());
   const mountedRef = useRef(false);
@@ -174,7 +160,6 @@ function CurrentPAConnectivity(_: Props) {
     controllerRef.current.setArea(areaTypeId, areaIdId);
     dpcRequestIdRef.current += 1;
 
-    setLoadingLayer(true);
     loadDpcData(false);
 
     BackendAPI.requestSectionTexts("paConnDPC")
@@ -190,34 +175,11 @@ function CurrentPAConnectivity(_: Props) {
         });
       });
 
-    controllerRef.current
-      .getLayer()
-      .then((currentPAConnLayer) => {
-        if (!mountedRef.current) return;
-        dispatch({ type: "SET_LAYERS", payload: [currentPAConnLayer] });
-        setShowAreaLayer(true);
-        setShapeLayers([currentPAConnLayer]);
-        setMapTitle({ name: "Conectividad de áreas protegidas" });
-        setLoadingLayer(false);
-      })
-      .catch((error) => {
-        setLayerError(error);
-        setLoadingLayer(false);
-      });
-
     return () => {
       mountedRef.current = false;
       controllerRef.current.cancelActiveRequests();
     };
-  }, [
-    areaType,
-    areaId,
-    setLoadingLayer,
-    setLayerError,
-    setMapTitle,
-    setShapeLayers,
-    setShowAreaLayer,
-  ]);
+  }, [areaType, areaId]);
 
   const toggleInfo = (value: string) => {
     dispatch({ type: "TOGGLE_INFO", payload: value });
@@ -225,17 +187,6 @@ function CurrentPAConnectivity(_: Props) {
 
   const toggleDpcMode = () => {
     loadDpcData(!state.showLowestDpc);
-  };
-
-  const highlightFeature = (selectedKey: string) => {
-    const highlightedLayers = state.layers.map((layer) => {
-      if (layer.id === "currentPAConn") {
-        layer.layerStyle = controllerRef.current.setLayerStyle(selectedKey);
-      }
-      return layer;
-    });
-    setShapeLayers(highlightedLayers);
-    dispatch({ type: "SET_LAYERS", payload: highlightedLayers });
   };
 
   const { dpcData, showLowestDpc, infoShown, messages, texts, graphData } =
@@ -286,9 +237,7 @@ function CurrentPAConnectivity(_: Props) {
               tooltips={graphData.tooltips}
               loadStatus={messages.dpc}
               colors={matchColor("dpc")}
-              onClickHandler={(selected: string) => {
-                highlightFeature(selected);
-              }}
+              onClickHandler={() => {}}
               animate={false}
               margin={{
                 bottom: 50,

--- a/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivity.tsx
+++ b/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivity.tsx
@@ -167,7 +167,7 @@ function CurrentPAConnectivity(_: Props) {
       });
 
     return () => {
-      controllerRef.current.cancelActiveRequests();
+      controller.cancelActiveRequests();
     };
   }, [areaType, areaId]);
 
@@ -233,9 +233,10 @@ function CurrentPAConnectivity(_: Props) {
               tooltips={graphData.tooltips}
               loadStatus={messages.dpc}
               colors={(key: string) =>
-                matchColor("coverage")(key) || colorPalettes.default[0]
+                matchColor("dpc")(key) || colorPalettes.default[0]
               }
               onClickHandler={() => {}}
+              animate={false}
               margin={{
                 bottom: 50,
                 left: 40,

--- a/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivity.tsx
+++ b/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivity.tsx
@@ -1,31 +1,28 @@
-import React from "react";
+import { useContext, useEffect, useReducer, useRef } from "react";
 import InfoIcon from "@mui/icons-material/Info";
 
 import { PointFilledLegend } from "@ui/CssLegends";
 import { ShortInfo } from "@composites/ShortInfo";
 import { IconTooltip } from "@ui/Tooltips";
+import { Button } from "@ui/shadCN/component/button";
 import {
   SearchLegacyCTX,
   type LegacyContextValues,
 } from "pages/search/hooks/SearchContext";
-import { matchColor } from "pages/search/utils/matchColor";
 import BackendAPI from "pages/search/api/backendAPI";
-import { formatNumber } from "@utils/format";
+import { matchColor } from "pages/search/utils/matchColor";
 import TextBoxes from "@ui/TextBoxes";
 
-import { currentPAConn, DPCKeys, DPC } from "pages/search/types/connectivity";
+import { DPC, DPCKeys } from "pages/search/types/connectivity";
 import { textsObject } from "pages/search/types/texts";
-import { SmallBars } from "@composites/charts/SmallBars";
+import {
+  SmallBars,
+  SmallBarsData,
+  type SmallBarTooltip,
+} from "@composites/charts/SmallBars";
 import { type MessageWrapperType } from "@composites/charts/withMessageWrapper";
-import LargeStackedBar from "@composites/charts/LargeStackedBar";
 import { CurrentPAConnectivityController } from "pages/search/dashboard/landscape/connectivity/CurrentPAConnectivityController";
 import { ShapeLayer } from "pages/search/types/layers";
-
-const getLabel = {
-  unprot: "No protegida",
-  prot_conn: "Protegida conectada",
-  prot_unconn: "Protegida no conectada",
-};
 
 const legendDPCCategories = {
   muy_bajo: "Muy bajo",
@@ -35,275 +32,264 @@ const legendDPCCategories = {
   muy_alto: "Muy Alto",
 };
 
-interface currentPAConnExt extends currentPAConn {
-  label: string;
-}
-
 interface Props {}
 
-interface currentPAConnState {
+interface CurrentPAConnState {
   infoShown: Set<string>;
-  currentPAConnData: Array<currentPAConnExt>;
   dpcData: Array<DPC>;
-  prot: number;
+  showLowestDpc: boolean;
   messages: {
-    conn: MessageWrapperType;
     dpc: MessageWrapperType;
   };
+  graphData: {
+    transformedData: Array<SmallBarsData>;
+    keys: Array<string>;
+    tooltips: Array<SmallBarTooltip>;
+  };
   texts: {
-    paConnCurrent: textsObject;
     paConnDPC: textsObject;
   };
   layers: Array<ShapeLayer>;
 }
 
-class CurrentPAConnectivity extends React.Component<Props, currentPAConnState> {
-  static contextType = SearchLegacyCTX;
-  mounted = false;
-  componentName = "currentPAConn";
-  CPACController;
+type DpcPayload = {
+  dpcData: Array<DPC>;
+  graphData: {
+    transformedData: Array<SmallBarsData>;
+    keys: Array<string>;
+    tooltips: Array<SmallBarTooltip>;
+  };
+};
 
-  constructor(props: Props) {
-    super(props);
-    this.CPACController = new CurrentPAConnectivityController();
-    this.mounted = false;
-    this.state = {
-      infoShown: new Set(["current"]),
-      currentPAConnData: [],
-      dpcData: [],
-      prot: 0,
-      messages: {
-        conn: "loading",
-        dpc: "loading",
-      },
-      texts: {
-        paConnCurrent: { info: "", cons: "", meto: "", quote: "" },
-        paConnDPC: { info: "", cons: "", meto: "", quote: "" },
-      },
-      layers: [],
-    };
+type Action =
+  | { type: "TOGGLE_INFO"; payload: string }
+  | { type: "SET_SHOW_LOWEST"; payload: boolean }
+  | { type: "DPC_SUCCEEDED"; payload: DpcPayload }
+  | { type: "DPC_FAILED" }
+  | { type: "SET_TEXTS"; payload: textsObject }
+  | { type: "SET_LAYERS"; payload: Array<ShapeLayer> };
+
+const initialState: CurrentPAConnState = {
+  infoShown: new Set(["dpc"]),
+  dpcData: [],
+  showLowestDpc: false,
+  messages: {
+    dpc: "loading",
+  },
+  graphData: {
+    transformedData: [],
+    keys: [],
+    tooltips: [],
+  },
+  texts: {
+    paConnDPC: { info: "", cons: "", meto: "", quote: "" },
+  },
+  layers: [],
+};
+
+function reducer(
+  state: CurrentPAConnState,
+  action: Action,
+): CurrentPAConnState {
+  switch (action.type) {
+    case "TOGGLE_INFO": {
+      const infoShown = new Set(state.infoShown);
+      if (infoShown.has(action.payload)) infoShown.delete(action.payload);
+      else infoShown.add(action.payload);
+      return { ...state, infoShown };
+    }
+    case "SET_SHOW_LOWEST":
+      return {
+        ...state,
+        showLowestDpc: action.payload,
+        messages: { ...state.messages, dpc: "loading" },
+      };
+    case "DPC_SUCCEEDED":
+      return {
+        ...state,
+        dpcData: action.payload.dpcData,
+        graphData: action.payload.graphData,
+        messages: { ...state.messages, dpc: null },
+      };
+    case "DPC_FAILED":
+      return {
+        ...state,
+        messages: { ...state.messages, dpc: "no-data" },
+      };
+    case "SET_TEXTS":
+      return { ...state, texts: { paConnDPC: action.payload } };
+    case "SET_LAYERS":
+      return { ...state, layers: action.payload };
+    default:
+      return state;
   }
+}
 
-  componentDidMount() {
-    this.mounted = true;
-    const {
-      areaType,
-      areaId,
-      setShapeLayers,
-      setLoadingLayer,
-      setLayerError,
-      setMapTitle,
-      setShowAreaLayer,
-    } = this.context as LegacyContextValues;
+function CurrentPAConnectivity(_: Props) {
+  const context = useContext(SearchLegacyCTX) as LegacyContextValues;
+  const {
+    areaType,
+    areaId,
+    setShapeLayers,
+    setLoadingLayer,
+    setLayerError,
+    setMapTitle,
+    setShowAreaLayer,
+  } = context;
 
-    const areaTypeId = areaType!.id;
-    const areaIdId = areaId!.id.toString();
+  const controllerRef = useRef(new CurrentPAConnectivityController());
+  const mountedRef = useRef(false);
+  const dpcRequestIdRef = useRef(0);
 
-    this.CPACController.setArea(areaTypeId, areaIdId);
+  const [state, dispatch] = useReducer(reducer, initialState);
 
-    BackendAPI.requestCurrentPAConnectivity(areaTypeId, areaIdId)
-      .then((res: Array<currentPAConn>) => {
-        if (this.mounted) {
-          const protConn = res.find((item) => item.key === "prot_conn");
-          const protUnconn = res.find((item) => item.key === "prot_unconn");
-          this.setState((prev) => ({
-            currentPAConnData: res.map((item) => ({
-              ...item,
-              label: getLabel[item.key],
-            })),
-            prot:
-              protConn && protUnconn
-                ? (protConn.percentage + protUnconn.percentage) * 100
-                : 0,
-            messages: {
-              ...prev.messages,
-              conn: null,
-            },
-          }));
-        }
+  const loadDpcData = (showLowestDpc: boolean) => {
+    dispatch({ type: "SET_SHOW_LOWEST", payload: showLowestDpc });
+
+    const requestId = ++dpcRequestIdRef.current;
+
+    controllerRef.current
+      .getDpcData(showLowestDpc)
+      .then((result) => {
+        if (!mountedRef.current || requestId !== dpcRequestIdRef.current)
+          return;
+        dispatch({ type: "DPC_SUCCEEDED", payload: result });
       })
       .catch(() => {
-        this.setState((prev) => ({
-          messages: {
-            ...prev.messages,
-            conn: "no-data",
-          },
-        }));
+        if (!mountedRef.current || requestId !== dpcRequestIdRef.current)
+          return;
+        dispatch({ type: "DPC_FAILED" });
       });
-
-    BackendAPI.requestDPC(areaTypeId, areaIdId, 5)
-      .then((res: Array<DPC>) => {
-        if (this.mounted) {
-          this.setState((prev) => ({
-            dpcData: res.reverse(),
-            messages: {
-              ...prev.messages,
-              dpc: null,
-            },
-          }));
-        }
-      })
-      .catch(() => {
-        this.setState((prev) => ({
-          messages: {
-            ...prev.messages,
-            dpc: "no-data",
-          },
-        }));
-      });
-
-    ["paConnCurrent", "paConnDPC"].forEach((item) => {
-      BackendAPI.requestSectionTexts(item)
-        .then((res) => {
-          if (this.mounted) {
-            this.setState((prevState) => ({
-              texts: { ...prevState.texts, [item]: res },
-            }));
-          }
-        })
-        .catch(() => {
-          this.setState((prevState) => ({
-            texts: {
-              ...prevState.texts,
-              [item]: { info: "", cons: "", meto: "", quote: "" },
-            },
-          }));
-        });
-    });
-
-    setLoadingLayer(true);
-
-    this.CPACController.getLayer()
-      .then((currentPAConn) => {
-        if (this.mounted) {
-          this.setState(
-            () => ({ layers: [currentPAConn] }),
-            () => setLoadingLayer(false),
-          );
-          setShowAreaLayer(true);
-          setShapeLayers(this.state.layers);
-          setMapTitle({ name: "Conectividad de áreas protegidas" });
-        }
-      })
-      .catch((error) => setLayerError(error));
-  }
-
-  componentWillUnmount() {
-    this.mounted = false;
-    this.CPACController.cancelActiveRequests();
-  }
-
-  toggleInfo = (value: string) => {
-    this.setState((prev) => {
-      const newState = prev;
-      if (prev.infoShown.has(value)) {
-        newState.infoShown.delete(value);
-        return newState;
-      }
-      newState.infoShown.add(value);
-      return newState;
-    });
   };
 
-  render() {
-    const { areaType, areaId } = this.context as LegacyContextValues;
-    const {
-      currentPAConnData,
-      dpcData,
-      prot,
-      infoShown,
-      messages: { conn, dpc: dpcMess },
-      texts,
-    } = this.state;
+  useEffect(() => {
+    if (!areaType || !areaId) {
+      return;
+    }
 
-    const areaTypeId = areaType!.id;
-    const areaIdId = areaId!.id.toString();
+    mountedRef.current = true;
+    const areaTypeId = areaType.id;
+    const areaIdId = areaId.id.toString();
 
-    const graphData = this.CPACController.getGraphData(dpcData);
+    controllerRef.current.setArea(areaTypeId, areaIdId);
+    dpcRequestIdRef.current += 1;
 
-    return (
-      <div className="graphcontainer pt6">
-        <h2>
-          <IconTooltip title="Interpretación">
-            <InfoIcon
-              className={`graphinfo${
-                infoShown.has("current") ? " activeBox" : ""
-              }`}
-              onClick={() => this.toggleInfo("current")}
-            />
-          </IconTooltip>
-        </h2>
-        {infoShown.has("current") && (
+    setLoadingLayer(true);
+    loadDpcData(false);
+
+    BackendAPI.requestSectionTexts("paConnDPC")
+      .then((res) => {
+        if (!mountedRef.current) return;
+        dispatch({ type: "SET_TEXTS", payload: res });
+      })
+      .catch(() => {
+        if (!mountedRef.current) return;
+        dispatch({
+          type: "SET_TEXTS",
+          payload: { info: "", cons: "", meto: "", quote: "" },
+        });
+      });
+
+    controllerRef.current
+      .getLayer()
+      .then((currentPAConnLayer) => {
+        if (!mountedRef.current) return;
+        dispatch({ type: "SET_LAYERS", payload: [currentPAConnLayer] });
+        setShowAreaLayer(true);
+        setShapeLayers([currentPAConnLayer]);
+        setMapTitle({ name: "Conectividad de áreas protegidas" });
+        setLoadingLayer(false);
+      })
+      .catch((error) => {
+        setLayerError(error);
+        setLoadingLayer(false);
+      });
+
+    return () => {
+      mountedRef.current = false;
+      controllerRef.current.cancelActiveRequests();
+    };
+  }, [
+    areaType,
+    areaId,
+    setLoadingLayer,
+    setLayerError,
+    setMapTitle,
+    setShapeLayers,
+    setShowAreaLayer,
+  ]);
+
+  const toggleInfo = (value: string) => {
+    dispatch({ type: "TOGGLE_INFO", payload: value });
+  };
+
+  const toggleDpcMode = () => {
+    loadDpcData(!state.showLowestDpc);
+  };
+
+  const highlightFeature = (selectedKey: string) => {
+    const highlightedLayers = state.layers.map((layer) => {
+      if (layer.id === "currentPAConn") {
+        layer.layerStyle = controllerRef.current.setLayerStyle(selectedKey);
+      }
+      return layer;
+    });
+    setShapeLayers(highlightedLayers);
+    dispatch({ type: "SET_LAYERS", payload: highlightedLayers });
+  };
+
+  const { dpcData, showLowestDpc, infoShown, messages, texts, graphData } =
+    state;
+  const areaTypeId = areaType!.id;
+  const areaIdId = areaId!.id.toString();
+
+  return (
+    <div className="graphcontainer pt6">
+      <div>
+        <h6>Aporte de las áreas protegidas a la conectividad</h6>
+        <div className="mb2 flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={toggleDpcMode}
+          >
+            {showLowestDpc ? "Áreas con mayor dPC" : "Áreas con menor dPC"}
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            {showLowestDpc
+              ? "Áreas que menos aportan."
+              : "Áreas que más aportan."}
+          </span>
+        </div>
+        <IconTooltip title="Interpretación">
+          <InfoIcon
+            className={`downSpecial${infoShown.has("dpc") ? " activeBox" : ""}`}
+            onClick={() => toggleInfo("dpc")}
+          />
+        </IconTooltip>
+        {infoShown.has("dpc") && (
           <ShortInfo
-            description={`<p>${texts.paConnCurrent.info}</p>`}
+            description={`<p>${texts.paConnDPC.info}</p>`}
             className="graphinfo2"
             collapseButton={false}
           />
         )}
+        <h3 className="innerInfoH3">
+          Haz clic en un área protegida para visualizarla
+        </h3>
         <div>
-          <h6>Conectividad áreas protegidas</h6>
-          <div>
-            <LargeStackedBar
-              data={currentPAConnData}
-              message={conn}
-              labelX="Hectáreas"
-              labelY="Conectividad Áreas Protegidas"
-              units="ha"
-              colors={matchColor("currentPAConn")}
-              padding={0.25}
-            />
-            <TextBoxes
-              consText={texts.paConnCurrent.cons}
-              metoText={texts.paConnCurrent.meto}
-              quoteText={texts.paConnCurrent.quote}
-              downloadData={currentPAConnData}
-              downloadName={`conn_current_${areaTypeId}_${areaIdId}.csv`}
-              toggleInfo={() => this.toggleInfo("current")}
-              isInfoOpen={infoShown.has("current")}
-            />
-          </div>
-          {currentPAConnData.length > 0 && (
-            <div>
-              <h6 className="innerInfo">Porcentaje de área protegida</h6>
-              <h5
-                className="innerInfoH5"
-                style={{
-                  backgroundColor: matchColor("timelinePAConn")("prot"),
-                }}
-              >
-                {`${formatNumber(prot, 2)}%`}
-              </h5>
-            </div>
-          )}
-          <h6>Aporte de las áreas protegidas a la conectividad</h6>
-          <IconTooltip title="Interpretación">
-            <InfoIcon
-              className={`downSpecial${
-                infoShown.has("dpc") ? " activeBox" : ""
-              }`}
-              onClick={() => this.toggleInfo("dpc")}
-            />
-          </IconTooltip>
-          {infoShown.has("dpc") && (
-            <ShortInfo
-              description={`<p>${texts.paConnDPC.info}</p>`}
-              className="graphinfo2"
-              collapseButton={false}
-            />
-          )}
-          <h3 className="innerInfoH3">
-            Haz clic en un área protegida para visualizarla
-          </h3>
-          <div>
+          {dpcData.length > 0 && (
             <SmallBars
               data={graphData.transformedData}
               keys={graphData.keys}
               tooltips={graphData.tooltips}
-              loadStatus={dpcMess}
+              loadStatus={messages.dpc}
               colors={matchColor("dpc")}
               onClickHandler={(selected: string) => {
-                this.highlightFeature(selected);
+                highlightFeature(selected);
               }}
+              animate={false}
               margin={{
                 bottom: 50,
                 left: 40,
@@ -315,44 +301,27 @@ class CurrentPAConnectivity extends React.Component<Props, currentPAConnState> {
               }}
               enableLabel={true}
             />
-          </div>
-          <div className="dpcLegend">
-            {DPCKeys.map((cat) => (
-              <PointFilledLegend color={matchColor("dpc")(cat)} key={cat}>
-                {legendDPCCategories[cat]}
-              </PointFilledLegend>
-            ))}
-          </div>
-          <TextBoxes
-            consText={texts.paConnDPC.cons}
-            metoText={texts.paConnDPC.meto}
-            quoteText={texts.paConnDPC.quote}
-            downloadData={dpcData}
-            downloadName={`conn_dpc_${areaTypeId}_${areaIdId}.csv`}
-            isInfoOpen={infoShown.has("dpc")}
-            toggleInfo={() => this.toggleInfo("dpc")}
-          />
+          )}
         </div>
+        <div className="dpcLegend">
+          {DPCKeys.map((cat) => (
+            <PointFilledLegend color={matchColor("dpc")(cat)} key={cat}>
+              {legendDPCCategories[cat]}
+            </PointFilledLegend>
+          ))}
+        </div>
+        <TextBoxes
+          consText={texts.paConnDPC.cons}
+          metoText={texts.paConnDPC.meto}
+          quoteText={texts.paConnDPC.quote}
+          downloadData={dpcData}
+          downloadName={`conn_dpc_${areaTypeId}_${areaIdId}.csv`}
+          isInfoOpen={infoShown.has("dpc")}
+          toggleInfo={() => toggleInfo("dpc")}
+        />
       </div>
-    );
-  }
-
-  /**
-   * Highlight an specific feature of the Currenta PA layer
-   *
-   * @param {string} selectedKey Id of the feature
-   */
-  highlightFeature = (selectedKey: string) => {
-    const { setShapeLayers } = this.context as LegacyContextValues;
-    const { layers } = this.state;
-    const highlightedLayers = layers.map((layer) => {
-      if (layer.id === "currentPAConn") {
-        layer.layerStyle = this.CPACController.setLayerStyle(selectedKey);
-      }
-      return layer;
-    });
-    setShapeLayers(highlightedLayers);
-  };
+    </div>
+  );
 }
 
 export default CurrentPAConnectivity;

--- a/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivityController.ts
+++ b/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivityController.ts
@@ -84,7 +84,7 @@ export class CurrentPAConnectivityController {
 
     return {
       dpcData,
-      graphData: this.getGraphData(dpcData),
+      graphData: this.getGraphData(dpcData, showLowestDpc),
     };
   };
 
@@ -92,37 +92,37 @@ export class CurrentPAConnectivityController {
    * Transform data structure to be passed to component as a prop
    *
    * @param {Array<DPC>} rawData raw data from RestAPI
+   * @param {boolean} showLowestDpc whether the graph is showing the lower dpc values
    *
    * @returns {Array<SmallBarsData>} transformed data ready to be used by graph component
    */
-  getGraphData(rawData: Array<DPC>) {
+  getGraphData(rawData: Array<DPC>, showLowestDpc: boolean) {
     const tooltips: Array<SmallBarTooltip> = [];
     const categories: Set<string> = new Set();
-    const transformedData: Array<SmallBarsData> = [...rawData]
-      .reverse()
-      .map((pa) => {
-        const object = {
-          group: pa.id,
-          data: [
-            {
-              category: pa.key,
-              value: pa.value,
-            },
-          ],
-        };
+    const sortedForGraph = showLowestDpc ? rawData : [...rawData].reverse();
+    const transformedData: Array<SmallBarsData> = sortedForGraph.map((pa) => {
+      const object = {
+        group: pa.id,
+        data: [
+          {
+            category: pa.key,
+            value: pa.value,
+          },
+        ],
+      };
 
-        tooltips.push({
-          group: pa.id,
-          category: pa.key,
-          tooltipContent: [pa.name, `dPC: ${formatNumber(pa.value, 2)}`],
-        });
-
-        if (!categories.has(pa.key)) {
-          categories.add(pa.key);
-        }
-
-        return object;
+      tooltips.push({
+        group: pa.id,
+        category: pa.key,
+        tooltipContent: [pa.name, `dPC: ${formatNumber(pa.value, 2)}`],
       });
+
+      if (!categories.has(pa.key)) {
+        categories.add(pa.key);
+      }
+
+      return object;
+    });
 
     return { transformedData, keys: Array.from(categories), tooltips };
   }
@@ -208,11 +208,14 @@ export class CurrentPAConnectivityController {
    */
   setLayerStyle =
     (selectedKey = "") =>
-    (feature?: { properties: ConnectivityFeaturePropierties }) => ({
-      stroke: false,
-      fillColor: matchColor("dpc")(feature?.properties.dpc_cat),
-      fillOpacity: feature?.properties.id === selectedKey ? 1 : 0.6,
-    });
+    (feature?: { properties: ConnectivityFeaturePropierties }) => {
+      const color = matchColor("dpc")(feature?.properties.dpc_cat);
+      return {
+        stroke: false,
+        fillColor: (color ?? undefined) as string | undefined,
+        fillOpacity: feature?.properties.id === selectedKey ? 1 : 0.6,
+      };
+    };
 
   /**
    * Send the cancel signal to all active requests and remove them from the map

--- a/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivityController.ts
+++ b/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivityController.ts
@@ -98,29 +98,31 @@ export class CurrentPAConnectivityController {
   getGraphData(rawData: Array<DPC>) {
     const tooltips: Array<SmallBarTooltip> = [];
     const categories: Set<string> = new Set();
-    const transformedData: Array<SmallBarsData> = rawData.map((pa) => {
-      const object = {
-        group: pa.id,
-        data: [
-          {
-            category: pa.key,
-            value: pa.value,
-          },
-        ],
-      };
+    const transformedData: Array<SmallBarsData> = [...rawData]
+      .reverse()
+      .map((pa) => {
+        const object = {
+          group: pa.id,
+          data: [
+            {
+              category: pa.key,
+              value: pa.value,
+            },
+          ],
+        };
 
-      tooltips.push({
-        group: pa.id,
-        category: pa.key,
-        tooltipContent: [pa.name, `dPC: ${formatNumber(pa.value, 2)}`],
+        tooltips.push({
+          group: pa.id,
+          category: pa.key,
+          tooltipContent: [pa.name, `dPC: ${formatNumber(pa.value, 2)}`],
+        });
+
+        if (!categories.has(pa.key)) {
+          categories.add(pa.key);
+        }
+
+        return object;
       });
-
-      if (!categories.has(pa.key)) {
-        categories.add(pa.key);
-      }
-
-      return object;
-    });
 
     return { transformedData, keys: Array.from(categories), tooltips };
   }

--- a/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivityController.ts
+++ b/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivityController.ts
@@ -18,7 +18,6 @@ export class CurrentPAConnectivityController {
   areaType: string | null = null;
   areaId: string | null = null;
   activeRequests: Map<string, CancelTokenSource> = new Map();
-  dpcRequestId = 0;
 
   constructor() {}
 
@@ -38,11 +37,19 @@ export class CurrentPAConnectivityController {
     showLowestDpc: boolean,
   ): Promise<{ dpcData: Array<DPC>; graphData: DpcGraphData }> => {
     const areaId = Number(this.areaId ?? "");
-    const requestId = ++this.dpcRequestId;
+    const requestKey = "dpc";
+    this.activeRequests.get(requestKey)?.cancel();
 
-    const res = await SearchAPI.requestMetricsValues<"dpc">("dpc", areaId)
-      .request;
-    if (requestId !== this.dpcRequestId) {
+    const { request, source } = SearchAPI.requestMetricsValues<"dpc">(
+      "dpc",
+      areaId,
+    );
+    this.activeRequests.set(requestKey, source);
+
+    const res = await request;
+    this.activeRequests.delete(requestKey);
+
+    if (typeof res === "string") {
       throw new Error("request canceled");
     }
 
@@ -221,7 +228,6 @@ export class CurrentPAConnectivityController {
    * Send the cancel signal to all active requests and remove them from the map
    */
   cancelActiveRequests = () => {
-    this.dpcRequestId += 1;
     this.activeRequests.forEach((value, key) => {
       value.cancel();
       this.activeRequests.delete(key);

--- a/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivityController.ts
+++ b/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivityController.ts
@@ -1,5 +1,5 @@
 import { SmallBarsData } from "@composites/charts/SmallBars";
-import { DPC } from "pages/search/types/connectivity";
+import { DPC, DPCKeys } from "pages/search/types/connectivity";
 import { formatNumber } from "@utils/format";
 import { type SmallBarTooltip } from "@composites/charts/SmallBars";
 import SearchAPI from "pages/search/api/searchAPI";
@@ -71,7 +71,7 @@ export class CurrentPAConnectivityController {
     const withCategory = normalizedDpc.map((item) => {
       const rank = rankById.get(item.id) ?? 0;
       const percentile = total > 0 ? ((rank + 1) / total) * 100 : 0;
-      let key: "muy_bajo" | "bajo" | "medio" | "alto" | "muy_alto" = "muy_bajo";
+      let key: (typeof DPCKeys)[number] = "muy_bajo";
 
       if (percentile <= 20) key = "muy_bajo";
       else if (percentile <= 40) key = "bajo";

--- a/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivityController.ts
+++ b/src/pages/search/dashboard/landscape/connectivity/CurrentPAConnectivityController.ts
@@ -2,6 +2,7 @@ import { SmallBarsData } from "@composites/charts/SmallBars";
 import { DPC } from "pages/search/types/connectivity";
 import { formatNumber } from "@utils/format";
 import { type SmallBarTooltip } from "@composites/charts/SmallBars";
+import SearchAPI from "pages/search/api/searchAPI";
 import BackendAPI from "pages/search/api/backendAPI";
 import {
   ShapeLayer,
@@ -11,10 +12,13 @@ import { matchColor } from "pages/search/utils/matchColor";
 import { ShapeAPIObject } from "pages/search/types/api";
 import { CancelTokenSource } from "axios";
 
+type DpcGraphData = ReturnType<CurrentPAConnectivityController["getGraphData"]>;
+
 export class CurrentPAConnectivityController {
   areaType: string | null = null;
   areaId: string | null = null;
   activeRequests: Map<string, CancelTokenSource> = new Map();
+  dpcRequestId = 0;
 
   constructor() {}
 
@@ -22,6 +26,67 @@ export class CurrentPAConnectivityController {
     this.areaType = areaType;
     this.areaId = areaId;
   }
+
+  /**
+   * Get the values of connectivity for the protected areas with higher dPC value in a given area.
+   *
+   * @param {boolean} showLowestDpc whether to sort ascending or descending
+   *
+   * @returns {Promise<{ dpcData: Array<DPC>; graphData: DpcGraphData }>}
+   */
+  getDpcData = async (
+    showLowestDpc: boolean,
+  ): Promise<{ dpcData: Array<DPC>; graphData: DpcGraphData }> => {
+    const areaId = Number(this.areaId ?? "");
+    const requestId = ++this.dpcRequestId;
+
+    const res = await SearchAPI.requestMetricsValues<"dpc">("dpc", areaId)
+      .request;
+    if (requestId !== this.dpcRequestId) {
+      throw new Error("request canceled");
+    }
+
+    const normalizedDpc = [...res]
+      .map((item: any) => ({
+        id: String(item.id ?? item.pa_id ?? ""),
+        name: String(item.name ?? item.pa_name ?? ""),
+        area: Number(item.area ?? 0),
+        value: Number(item.value ?? item.dpc ?? 0),
+      }))
+      .filter((item) => item.value > 0);
+
+    const sortedByValue = [...normalizedDpc].sort((a, b) => a.value - b.value);
+    const total = sortedByValue.length;
+    const rankById = new Map(
+      sortedByValue.map((item, index) => [item.id, index]),
+    );
+
+    const withCategory = normalizedDpc.map((item) => {
+      const rank = rankById.get(item.id) ?? 0;
+      const percentile = total > 0 ? ((rank + 1) / total) * 100 : 0;
+      let key: "muy_bajo" | "bajo" | "medio" | "alto" | "muy_alto" = "muy_bajo";
+
+      if (percentile <= 20) key = "muy_bajo";
+      else if (percentile <= 40) key = "bajo";
+      else if (percentile <= 60) key = "medio";
+      else if (percentile <= 80) key = "alto";
+      else key = "muy_alto";
+
+      return {
+        ...item,
+        key,
+      };
+    });
+
+    const dpcData = withCategory
+      .sort((a, b) => (showLowestDpc ? a.value - b.value : b.value - a.value))
+      .slice(0, 5) as DPC[];
+
+    return {
+      dpcData,
+      graphData: this.getGraphData(dpcData),
+    };
+  };
 
   /**
    * Transform data structure to be passed to component as a prop
@@ -47,11 +112,7 @@ export class CurrentPAConnectivityController {
       tooltips.push({
         group: pa.id,
         category: pa.key,
-        tooltipContent: [
-          pa.name,
-          `${formatNumber(pa.value, 2)}`,
-          `${formatNumber(pa.area, 2)} ha`,
-        ],
+        tooltipContent: [pa.name, `dPC: ${formatNumber(pa.value, 2)}`],
       });
 
       if (!categories.has(pa.key)) {
@@ -155,6 +216,7 @@ export class CurrentPAConnectivityController {
    * Send the cancel signal to all active requests and remove them from the map
    */
   cancelActiveRequests = () => {
+    this.dpcRequestId += 1;
     this.activeRequests.forEach((value, key) => {
       value.cancel();
       this.activeRequests.delete(key);

--- a/src/pages/search/types/metrics.ts
+++ b/src/pages/search/types/metrics.ts
@@ -36,6 +36,7 @@ export type MetricTypesMap = {
     "Natural" | "Secundaria" | "Transformada"
   >;
   protectedAreas: MetricDataStructure<"id", string>;
+  dpc: Array<MetricDataStructure<"id" | "name" | "key", "area" | "value">>;
 };
 
 export type MetricsTypes = keyof MetricTypesMap;


### PR DESCRIPTION
## 🛠️ Changes
- The current protected areas connectivity component is enabled.
- The component is refactored to functional logic.
- Button to view areas with lower DPC

## 📝 Associated issues
- Part of LIB-700

## 🤔 Considerations
- It's necessary to load the dpc CSV into the search backend using the populate command
- To obtain the sorted list of areas, there is a branch in the search backend [Order dPC output list](https://github.com/PEM-Humboldt/biotablero-search-backend/tree/ManuelStardust/LIB-700)


## ✅ Checks
