### PR TITLE
Agrega las capas del geoserver al buscador de iniciativas

### DIFF
--- a/src/pages/monitoring/outlets/initiativesMap/MapFinder.tsx
+++ b/src/pages/monitoring/outlets/initiativesMap/MapFinder.tsx
@@ -39,8 +39,8 @@ export function MapFinder({
   leastInitiativesPerDepartment,
   mostInitiativesPerDepartment,
 }: {
-  tiles: keyof typeof MAP_TILES;
-  layer: keyof typeof MAP_LAYERS | null;
+  tiles: number;
+  layer: number | null;
   nation: FeatureCollection | null;
   initiatives: InitiativeByLocation[];
   activeFeatures: {
@@ -152,7 +152,12 @@ export function MapFinder({
     });
   };
 
-  const mapAttribution = `${MAP_TILES[tiles].attribution}${layer !== null && MAP_LAYERS[layer]?.attribution ? ` || ${MAP_LAYERS[layer].attribution}` : ""}`;
+  const layerAttribution =
+    layer !== null && MAP_LAYERS[layer].attribution
+      ? ` || ${MAP_LAYERS[layer].attribution}`
+      : "";
+  const tilesAttribution = MAP_TILES[tiles].attribution;
+  const mapAttribution = `${tilesAttribution}${layerAttribution}`;
 
   return (
     <MapContainer

--- a/src/pages/monitoring/outlets/initiativesMap/MapFinder.tsx
+++ b/src/pages/monitoring/outlets/initiativesMap/MapFinder.tsx
@@ -152,6 +152,8 @@ export function MapFinder({
     });
   };
 
+  const mapAttribution = `${MAP_TILES[tiles].attribution}${layer !== null && MAP_LAYERS[layer]?.attribution ? ` || ${MAP_LAYERS[layer].attribution}` : ""}`;
+
   return (
     <MapContainer
       bounds={bounds ?? COUNTRY_BOUNDS}
@@ -192,7 +194,7 @@ export function MapFinder({
 
       <TileLayer
         key={`tile-layer-${tiles}`}
-        attribution={MAP_TILES[tiles].attribution}
+        attribution={mapAttribution}
         url={MAP_TILES[tiles].url}
       />
 

--- a/src/pages/monitoring/outlets/initiativesMap/MapFinder.tsx
+++ b/src/pages/monitoring/outlets/initiativesMap/MapFinder.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import L, { type LatLngBoundsLiteral } from "leaflet";
-import { MapContainer, TileLayer, GeoJSON } from "react-leaflet";
+import { MapContainer, TileLayer, GeoJSON, WMSTileLayer } from "react-leaflet";
 import MarkerClusterGroup from "react-leaflet-cluster";
 import type {
   Feature,
@@ -21,13 +21,14 @@ import {
 } from "pages/monitoring/outlets/initiativesMap/mapFinder/MapMarker";
 import { ZoomControls } from "pages/monitoring/outlets/initiativesMap/mapFinder/ZoomControls";
 import {
-  type MAP_LAYERS,
+  MAP_LAYERS,
   MAP_TILES,
 } from "pages/monitoring/outlets/initiativesMap/layout/layers";
 import type {
   DeptFeature,
   DeptProperties,
 } from "pages/monitoring/outlets/initiativesMap/types/mapFeatures";
+import { Spinner } from "@ui/shadCN/component/spinner";
 
 export function MapFinder({
   tiles,
@@ -53,6 +54,7 @@ export function MapFinder({
   const navigate = useNavigate();
   const [center, setCenter] = useState<L.LatLng | null>(null);
   const [bounds, setBounds] = useState<LatLngBoundsLiteral | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     if (!nation || !nation.features) {
@@ -193,6 +195,39 @@ export function MapFinder({
         attribution={MAP_TILES[tiles].attribution}
         url={MAP_TILES[tiles].url}
       />
+
+      {layer !== null && (
+        <WMSTileLayer
+          key={`${MAP_LAYERS[layer].url}-${MAP_LAYERS[layer].layers}`}
+          url={MAP_LAYERS[layer].url}
+          layers={MAP_LAYERS[layer].layers}
+          format="image/png"
+          transparent={true}
+          version="1.1.0"
+          zIndex={10}
+          eventHandlers={{
+            loading: () => {
+              setIsLoading(true);
+            },
+            load: () => {
+              setIsLoading(false);
+            },
+            tileerror: () => {
+              setIsLoading(false);
+              console.error("Error loading layer");
+            },
+          }}
+        />
+      )}
+
+      {isLoading && (
+        <div className="absolute inset-0 z-1000 bg-primary/50 backdrop-blur-[5px] flex flex-col items-center justify-center gap-2">
+          <Spinner className="size-10 text-primary-foreground" />
+          <span className="text-primary-foreground text-2xl font-normal">
+            Cargando capa geográfica...
+          </span>
+        </div>
+      )}
     </MapContainer>
   );
 }

--- a/src/pages/monitoring/outlets/initiativesMap/layout/layers.ts
+++ b/src/pages/monitoring/outlets/initiativesMap/layout/layers.ts
@@ -33,27 +33,31 @@ export const MAP_TILES = {
 
 export const MAP_LAYERS = {
   0: {
-    label: "Deforestación",
+    label: "Páramos",
     attribution: "",
-    url: "",
+    url: "https://geoservicios.humboldt.org.co/geoserver/wms",
+    layers: "Proyecto_fondo_adaptacion:Limites24Paramos_25K_2016",
     buttonBkg: deforestationBtn,
   },
   1: {
-    label: "Bosques",
+    label: "Cobertura boscosa",
     attribution: "",
-    url: "",
+    url: "https://geoservicios.humboldt.org.co/geoserver/ideam/wms",
+    layers: "ideam:bnb_2024_v8",
     buttonBkg: forestBtn,
   },
   2: {
-    label: "Fuentes hídricas",
-    attribution: "",
-    url: "",
+    label: "Humedales",
+    url: "https://geoservicios.humboldt.org.co/geoserver/wms",
+    layers:
+      "Proyecto_fondo_adaptacion:Humedales_Continentales_Insulares_2015_Vector",
     buttonBkg: waterResourcesBtn,
   },
   3: {
-    label: "Vías",
+    label: "Áreas protegidas",
     attribution: "",
-    url: "",
+    url: "https://mapas.parquesnacionales.gov.co/services/pnn/wms",
+    layers: "pnn:runap",
     buttonBkg: roadsBtn,
   },
 };

--- a/src/pages/monitoring/outlets/initiativesMap/layout/layers.ts
+++ b/src/pages/monitoring/outlets/initiativesMap/layout/layers.ts
@@ -49,6 +49,7 @@ export const MAP_LAYERS = {
   2: {
     label: "Humedales",
     url: "https://geoservicios.humboldt.org.co/geoserver/wms",
+    attribution: "",
     layers:
       "Proyecto_fondo_adaptacion:Humedales_Continentales_Insulares_2015_Vector",
     buttonBkg: waterResourcesBtn,

--- a/src/pages/monitoring/outlets/initiativesMap/layout/layers.ts
+++ b/src/pages/monitoring/outlets/initiativesMap/layout/layers.ts
@@ -7,46 +7,46 @@ import forestBtn from "@assets/mapButtons/bosques.png";
 import waterResourcesBtn from "@assets/mapButtons/fuentesHidricas.png";
 import roadsBtn from "@assets/mapButtons/vias.png";
 
-export const MAP_TILES = {
-  0: {
+export const MAP_TILES = [
+  {
     label: "Político",
     attribution:
       '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors',
     url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
     uiThumbs: { button: politicalSelection, selection: satelitalSelection },
   },
-  1: {
+  {
     label: "Topográfico",
     attribution:
       'Sources: Esri, HERE, Garmin, Intermap, increment P Corp., GEBCO, USGS, FAO, NPS, NRCAN, GeoBase, IGN, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), (c) OpenStreetMap contributors, and the GIS User Community | Powered by <a href="https://www.esri.com/">Esri</a>',
     url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}",
     uiThumbs: { button: topographicSelection, selection: satelitalSelection },
   },
-  2: {
+  {
     label: "Satelital",
     attribution:
       'Sources: Esri, Vantor, Earthstar Geographics, and the GIS User Community | Powered by <a href="https://www.esri.com/">Esri</a>',
     url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
     uiThumbs: { button: satelitalSelection, selection: satelitalSelection },
   },
-} as const;
+] as const;
 
-export const MAP_LAYERS = {
-  0: {
+export const MAP_LAYERS = [
+  {
     label: "Páramos",
     attribution: "",
     url: "https://geoservicios.humboldt.org.co/geoserver/wms",
     layers: "Proyecto_fondo_adaptacion:Limites24Paramos_25K_2016",
     buttonBkg: deforestationBtn,
   },
-  1: {
+  {
     label: "Cobertura boscosa",
     attribution: "",
     url: "https://geoservicios.humboldt.org.co/geoserver/ideam/wms",
     layers: "ideam:bnb_2024_v8",
     buttonBkg: forestBtn,
   },
-  2: {
+  {
     label: "Humedales",
     url: "https://geoservicios.humboldt.org.co/geoserver/wms",
     attribution: "",
@@ -54,11 +54,11 @@ export const MAP_LAYERS = {
       "Proyecto_fondo_adaptacion:Humedales_Continentales_Insulares_2015_Vector",
     buttonBkg: waterResourcesBtn,
   },
-  3: {
+  {
     label: "Áreas protegidas",
     attribution: "",
     url: "https://mapas.parquesnacionales.gov.co/services/pnn/wms",
     layers: "pnn:runap",
     buttonBkg: roadsBtn,
   },
-};
+] as const;


### PR DESCRIPTION
## 🛠️ Changes
nada raro, incorpora ya las capas del geoserver

## 📝 Associated issues
resolves [LIB-739](https://linear.app/biodev/issue/LIB-739/actualizacion-de-vista-principal-hu-bt-mc-0043-monitoreo-comunitario)

## 🤔 Considerations
En este momento está arrojando un error de un key repetido en el buscador, ese problema ya se atendió en [este pull](https://github.com/PEM-Humboldt/biotablero-frontend/pull/1057) así que no pararle bolas, además no interfiere con la funcionalidad