### PR TITLE
Corrección con Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ FROM node:$NODE_IMG_TAG AS release
 WORKDIR /app
 
 COPY --from=build /app/dist ./dist
+COPY serve.json .
 
 RUN npm install -g serve@~13.0.0
 
@@ -33,4 +34,4 @@ RUN chmod +x /generate-env.sh
 
 EXPOSE 5000
 ENTRYPOINT ["/generate-env.sh"]
-CMD [ "serve", "-p", "5000", "-s", "dist" ]
+CMD ["serve", "-p", "5000", "-s", "dist", "--config", "/app/serve.json"]

--- a/serve.json
+++ b/serve.json
@@ -1,0 +1,3 @@
+{
+  "cleanUrls": false
+}


### PR DESCRIPTION
## 🛠️ Cambios
Se corrigió un problema en el despliegue con Docker. 

El proxy inverso del Dockerfile (`serve`) por defecto habilita las "clean URLs". Esto causaba que cualquier petición a un archivo *.html se redireccionara a la misma ubicación quitando la extensión.

Esto genera problemas con el iframe para validar la autenticación con Keycloak. Al momento de acceder al sitio `silent-check-sso.html`, `serve` redireccionaba a la ubicación `silent-check-sso` y generaba problemas en la carga de la página.

## 📝 Tareas asociadas
Resuelve (parcialmente) [lib-832](https://linear.app/biodev/issue/LIB-832)
Part of [lib-832](https://linear.app/biodev/issue/LIB-832)

## 🤔 Consideraciones
Si desean probar el parche, pueden ejecutar estos pasos:

```sh
# Generar la imagen
docker build --build-arg BUILD_CMD=build:careless -t biotablero-front:TEST .
# Correr un nuevo contenedor
docker run -p 5000:5000 --env-file .env.local --name bt-front-tmp biotablero-front:TEST
# Verificar que la carga de la página esté funcionando correctamente (sin redirecciones)
curl -I http://localhost:5000/silent-check-sso.html
# Eliminar el contenedor
docker stop bt-front-tmp && docker rm bt-front-tmp
```

## ✅ Verificaciones
- No aplica.